### PR TITLE
chore: issue-767 CIの実行条件を関連ファイルの変更時に限定する

### DIFF
--- a/.github/workflows/ci-self-hosted.yml
+++ b/.github/workflows/ci-self-hosted.yml
@@ -16,9 +16,41 @@ env:
   CI: true
 
 jobs:
+  # 変更されたパスを検出
+  detect-changes:
+    name: Detect Changes
+    runs-on: self-hosted
+    outputs:
+      api: ${{ steps.filter.outputs.api }}
+      frontend: ${{ steps.filter.outputs.frontend }}
+      extension: ${{ steps.filter.outputs.extension }}
+      mcp: ${{ steps.filter.outputs.mcp }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      
+    - name: Detect changed paths
+      uses: dorny/paths-filter@v3
+      id: filter
+      with:
+        filters: |
+          api:
+            - 'api/**'
+            - '.github/workflows/ci-self-hosted.yml'
+          frontend:
+            - 'frontend/**'
+            - '.github/workflows/ci-self-hosted.yml'
+          extension:
+            - 'extension/**'
+            - '.github/workflows/ci-self-hosted.yml'
+          mcp:
+            - 'mcp/**'
+            - '.github/workflows/ci-self-hosted.yml'
   # API プロジェクトのテスト
   api-tests:
     name: API Tests
+    needs: detect-changes
+    if: needs.detect-changes.outputs.api == 'true'
     runs-on: self-hosted
     timeout-minutes: 10
 
@@ -50,6 +82,8 @@ jobs:
   # フロントエンド プロジェクトのテスト
   frontend-tests:
     name: Frontend Tests
+    needs: detect-changes
+    if: needs.detect-changes.outputs.frontend == 'true'
     runs-on: self-hosted
     timeout-minutes: 15
 
@@ -88,6 +122,8 @@ jobs:
   # Chrome拡張機能のテスト
   extension-tests:
     name: Extension Tests
+    needs: detect-changes
+    if: needs.detect-changes.outputs.extension == 'true'
     runs-on: self-hosted
     timeout-minutes: 5
 
@@ -119,6 +155,8 @@ jobs:
   # MCP プロジェクトのテスト
   mcp-tests:
     name: MCP Tests
+    needs: detect-changes
+    if: needs.detect-changes.outputs.mcp == 'true'
     runs-on: self-hosted
     timeout-minutes: 8
 


### PR DESCRIPTION
## 概要
CIの実行条件を関連ファイルの変更時に限定することで、不要なCI実行を抑制し、リソースを効率的に利用できるようにしました。

## 変更内容
- `detect-changes`ジョブを追加
  - `dorny/paths-filter@v3`を使用して変更されたファイルを検出
- 各テストジョブに条件付き実行を追加
  - `api-tests`: `api/**`の変更時のみ実行
  - `frontend-tests`: `frontend/**`の変更時のみ実行
  - `extension-tests`: `extension/**`の変更時のみ実行
  - `mcp-tests`: `mcp/**`の変更時のみ実行
- ワークフローファイル自体の変更時はすべてのテストを実行

## 動作確認
- [x] 各ディレクトリの変更時に対応するジョブのみが実行されることを確認
- [x] ワークフローファイルの変更時にすべてのジョブが実行されることを確認

## 関連Issue
Closes #767

🤖 Generated with [Claude Code](https://claude.ai/code)