### PR TITLE
🐛 MCPのassignLabelsToMultipleArticles関数のエラーを修正

### DIFF
--- a/mcp/src/index.ts
+++ b/mcp/src/index.ts
@@ -291,6 +291,20 @@ server.tool(
 	async ({ articleIds, labelName, description }) => {
 		// Destructure arguments
 		try {
+			// 入力値の検証
+			if (!articleIds || !Array.isArray(articleIds) || articleIds.length === 0) {
+				throw new Error("articleIds must be a non-empty array");
+			}
+			if (!labelName || typeof labelName !== "string") {
+				throw new Error("labelName must be a non-empty string");
+			}
+
+			console.log("Calling assignLabelsToMultipleArticles with:", {
+				articleIds,
+				labelName,
+				description,
+			});
+
 			const result = await apiClient.assignLabelsToMultipleArticles(
 				articleIds,
 				labelName,
@@ -309,9 +323,10 @@ server.tool(
 			const errorMessage =
 				error instanceof Error ? error.message : String(error);
 			console.error(
-				`Error in assignLabelsToMultipleArticles tool (articleIds: ${articleIds}, labelName: ${labelName}, description: ${description}):`,
+				`Error in assignLabelsToMultipleArticles tool (articleIds: ${JSON.stringify(articleIds)}, labelName: ${labelName}, description: ${description}):`,
 				errorMessage,
 			);
+			console.error("Full error details:", error);
 			return {
 				content: [
 					{

--- a/mcp/src/lib/apiClient.ts
+++ b/mcp/src/lib/apiClient.ts
@@ -414,9 +414,9 @@ export async function assignLabelsToMultipleArticles(
 			"Content-Type": "application/json",
 		},
 		body: JSON.stringify({
-			articleIds,
-			labelName,
-			description,
+			articleIds: articleIds,
+			labelName: labelName,
+			description: description,
 		}),
 	});
 
@@ -430,6 +430,9 @@ export async function assignLabelsToMultipleArticles(
 			`Failed to parse response for batch label assignment: ${errorMessage}`,
 		);
 	}
+
+	// デバッグ用：レスポンスをログ出力
+	console.log("Batch label assignment response:", JSON.stringify(data, null, 2));
 
 	if (!response.ok) {
 		let errorMessage = `Failed to batch assign label "${labelName}"`;
@@ -465,9 +468,19 @@ export async function assignLabelsToMultipleArticles(
 		);
 	}
 
-	// successプロパティを除いた結果を返す
-	const { success: _success, ...result } = parsed.data;
-	return result;
+	// parsed.dataがnullでないことを確認
+	if (!parsed.data) {
+		throw new Error("API returned null or undefined data for batch label assignment");
+	}
+
+	// successプロパティを除いた結果を安全に取得
+	try {
+		const { success: _success, ...result } = parsed.data;
+		return result;
+	} catch (error) {
+		console.error("Error destructuring parsed data:", parsed.data);
+		throw new Error(`Failed to process batch label assignment response: ${error}`);
+	}
 }
 
 // Schema for bookmark


### PR DESCRIPTION
## 概要
Issue #772 で報告された、MCPの`assignLabelsToMultipleArticles`関数実行時に発生する「Cannot convert undefined or null to object」エラーを修正しました。

## 変更内容
- 🔧 APIレスポンスのnullチェックとエラーハンドリングを強化
- 🛡️ スプレッド演算子使用時のtry-catchブロックを追加
- ✅ 入力値の検証を追加（articleIds、labelNameの妥当性チェック）
- 📝 デバッグ用のログ出力を追加して問題の特定を容易に

## 修正箇所
- `mcp/src/lib/apiClient.ts`: APIレスポンス処理の安全性向上
- `mcp/src/index.ts`: 入力値検証とエラーハンドリングの強化

## テスト
- ✅ ビルド成功
- ✅ 既存テストがすべてパス

## 関連Issue
Fixes #772

🤖 Generated with [Claude Code](https://claude.ai/code)