### PR TITLE
🐛 MCP: assignLabelsToMultipleArticles関数の実行時エラーを修正 #791

### DIFF
--- a/mcp/src/index.ts
+++ b/mcp/src/index.ts
@@ -292,7 +292,11 @@ server.tool(
 		// Destructure arguments
 		try {
 			// 入力値の検証
-			if (!articleIds || !Array.isArray(articleIds) || articleIds.length === 0) {
+			if (
+				!articleIds ||
+				!Array.isArray(articleIds) ||
+				articleIds.length === 0
+			) {
 				throw new Error("articleIds must be a non-empty array");
 			}
 			if (!labelName || typeof labelName !== "string") {

--- a/mcp/src/lib/apiClient.ts
+++ b/mcp/src/lib/apiClient.ts
@@ -432,7 +432,10 @@ export async function assignLabelsToMultipleArticles(
 	}
 
 	// デバッグ用：レスポンスをログ出力
-	console.log("Batch label assignment response:", JSON.stringify(data, null, 2));
+	console.log(
+		"Batch label assignment response:",
+		JSON.stringify(data, null, 2),
+	);
 
 	if (!response.ok) {
 		let errorMessage = `Failed to batch assign label "${labelName}"`;
@@ -468,19 +471,13 @@ export async function assignLabelsToMultipleArticles(
 		);
 	}
 
-	// parsed.dataがnullでないことを確認
-	if (!parsed.data) {
-		throw new Error("API returned null or undefined data for batch label assignment");
-	}
-
-	// successプロパティを除いた結果を安全に取得
-	try {
-		const { success: _success, ...result } = parsed.data;
-		return result;
-	} catch (error) {
-		console.error("Error destructuring parsed data:", parsed.data);
-		throw new Error(`Failed to process batch label assignment response: ${error}`);
-	}
+	// successプロパティを除いた結果を返す
+	return {
+		successful: parsed.data.successful,
+		skipped: parsed.data.skipped,
+		errors: parsed.data.errors,
+		label: parsed.data.label,
+	};
 }
 
 // Schema for bookmark

--- a/mcp/src/test/index.test.ts
+++ b/mcp/src/test/index.test.ts
@@ -1,7 +1,7 @@
 /**
  * MCPサーバーの基本テスト
  */
-import { describe, expect, test } from "vitest";
+import { describe, expect, test, vi } from "vitest";
 import * as apiClient from "../lib/apiClient.js";
 
 describe("MCP Server Basic Tests", () => {
@@ -19,5 +19,67 @@ describe("MCP Server Basic Tests", () => {
 		expect(typeof apiClient.getUnreadBookmarks).toBe("function");
 		expect(typeof apiClient.getReadBookmarks).toBe("function");
 		expect(typeof apiClient.markBookmarkAsRead).toBe("function");
+	});
+});
+
+describe("assignLabelsToMultipleArticles", () => {
+	test("正常なレスポンスを処理できること", async () => {
+		// fetchをモック化
+		const mockResponse = {
+			ok: true,
+			json: async () => ({
+				success: true,
+				successful: 2,
+				skipped: 1,
+				errors: [],
+				label: {
+					id: 1,
+					name: "テストラベル",
+					description: "テスト用の説明",
+					createdAt: "2024-01-01T00:00:00Z",
+					updatedAt: "2024-01-01T00:00:00Z",
+				},
+			}),
+		};
+
+		global.fetch = vi.fn().mockResolvedValue(mockResponse);
+		process.env.API_BASE_URL = "http://localhost:3000";
+
+		const result = await apiClient.assignLabelsToMultipleArticles(
+			[1, 2, 3],
+			"テストラベル",
+			"テスト用の説明",
+		);
+
+		expect(result).toEqual({
+			successful: 2,
+			skipped: 1,
+			errors: [],
+			label: {
+				id: 1,
+				name: "テストラベル",
+				description: "テスト用の説明",
+				createdAt: "2024-01-01T00:00:00Z",
+				updatedAt: "2024-01-01T00:00:00Z",
+			},
+		});
+	});
+
+	test("エラーレスポンスを適切に処理できること", async () => {
+		// fetchをモック化してエラーレスポンスを返す
+		const mockResponse = {
+			ok: false,
+			statusText: "Bad Request",
+			json: async () => ({
+				message: "Invalid request",
+			}),
+		};
+
+		global.fetch = vi.fn().mockResolvedValue(mockResponse);
+		process.env.API_BASE_URL = "http://localhost:3000";
+
+		await expect(
+			apiClient.assignLabelsToMultipleArticles([1], "テストラベル"),
+		).rejects.toThrow("Invalid request: Bad Request");
 	});
 });


### PR DESCRIPTION
## 概要
MCP（Model Context Protocol）サーバーの`assignLabelsToMultipleArticles`関数で発生していたデストラクチャリングエラーを修正しました。

## 問題
- エラーメッセージ: `Cannot convert undefined or null to object`
- 原因: `parsed.data`オブジェクトのデストラクチャリング時にエラーが発生

## 変更内容
### 🐛 バグ修正
- try-catchブロックと複雑なデストラクチャリング構文を削除
- シンプルで安全なオブジェクトプロパティアクセスに変更
- 不要な`null`チェックと型チェックを削除（Zodバリデーション後は不要）

### ✅ テスト追加
- 正常なレスポンスの処理テストを追加
- エラーレスポンスの処理テストを追加
- モックを使用した単体テストで動作を検証

## 動作確認
- [x] 単体テストがすべてパス
- [x] TypeScriptの型チェックがパス
- [x] Biomeによるリントチェックがパス

## 関連Issue
Fixes #791

🤖 Generated with [Claude Code](https://claude.ai/code)