### PR TITLE
✅ 自動ラベル付け機能の改善とテスト追加

### DIFF
--- a/.github/workflows/auto-labeling.yml
+++ b/.github/workflows/auto-labeling.yml
@@ -5,6 +5,20 @@ on:
     # 毎日午前9時（JST）に実行
     - cron: '0 0 * * *'
   workflow_dispatch: # 手動実行もサポート
+    inputs:
+      dry_run:
+        description: 'テストモード（実際の更新を行わない）'
+        required: false
+        default: 'false'
+        type: choice
+        options:
+          - 'true'
+          - 'false'
+      max_articles:
+        description: '処理する最大記事数（空の場合は全て）'
+        required: false
+        default: ''
+        type: string
 
 jobs:
   auto-label:
@@ -27,15 +41,25 @@ jobs:
           node-version: '20'
 
       - name: Install and Build MCP
+        id: build-mcp
         run: |
           cd mcp
           npm ci
           npm run build
           echo "MCPビルド完了"
+          echo "build_status=success" >> $GITHUB_OUTPUT
+        continue-on-error: true
 
-      - name: Run Claude Auto Labeling
-        id: claude-labeling
+      - name: Validate MCP Build
+        if: steps.build-mcp.outputs.build_status != 'success'
+        run: |
+          echo "::error::MCPのビルドに失敗しました"
+          exit 1
+
+      - name: Run Claude Auto Labeling (Attempt 1)
+        id: claude-labeling-1
         uses: anthropics/claude-code-action@beta
+        continue-on-error: true
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           
@@ -55,23 +79,221 @@ jobs:
           direct_prompt: |
             MCPツールを使用して記事の自動ラベル付けを実行してください。
             
+            環境設定：
+            - テストモード: ${{ github.event.inputs.dry_run || 'false' }}
+            - 最大処理記事数: ${{ github.event.inputs.max_articles || '制限なし' }}
+            
             以下の手順で処理を行ってください：
             
             1. まず、getLabels ツールを使用して既存のラベル一覧を取得してください。
             2. 次に、getUnlabeledArticles ツールを使用してラベル付けされていない記事を取得してください。
-            3. 各記事に対して、タイトルと内容から最も適切なラベルを判定してください。
+            3. ${{ github.event.inputs.max_articles && format('最大{0}件の記事を処理してください。', github.event.inputs.max_articles) || '全ての未ラベル記事を処理してください。' }}
+            4. 各記事に対して、タイトルと内容から最も適切なラベルを判定してください。
                - 技術系記事の場合: プログラミング言語、フレームワーク、ツール名などから判定
                - 概念的な記事の場合: アーキテクチャ、設計パターン、ベストプラクティスなどから判定
-            4. assignLabel ツールを使用して、判定したラベルを記事に割り当ててください。
-            5. 複数の記事に同じラベルを付ける場合は、assignLabelsToMultipleArticles ツールを使用して効率化してください。
+            5. ${{ github.event.inputs.dry_run == 'true' && 'テストモードのため、実際のラベル付けは行わず、判定結果のみ報告してください。' || 'assignLabel ツールを使用して、判定したラベルを記事に割り当ててください。' }}
+            6. 複数の記事に同じラベルを付ける場合は、assignLabelsToMultipleArticles ツールを使用して効率化してください。
             
-            処理結果として以下を報告してください：
-            - 処理した記事の総数
+            処理結果として以下を必ず報告してください：
+            - 処理対象記事の総数
+            - 処理完了記事数
             - 付与したラベルの内訳（ラベル名: 記事数）
             - 新規作成したラベル（もしあれば）
             - ラベル付けできなかった記事（もしあれば）とその理由
+            - エラーが発生した場合はその詳細
+            
+            出力形式：
+            ```summary
+            処理結果サマリー:
+            - 処理対象: X件
+            - 処理完了: Y件
+            - 処理失敗: Z件
+            ```
             
             注意事項：
             - 既存のラベルをできるだけ活用してください
             - 新しいラベルは本当に必要な場合のみ作成してください
             - ラベル名は簡潔で分かりやすいものにしてください
+            - エラーが発生した場合は詳細を報告してください
+
+      - name: Run Claude Auto Labeling (Retry - Attempt 2)
+        if: steps.claude-labeling-1.outcome == 'failure'
+        id: claude-labeling-2
+        uses: anthropics/claude-code-action@beta
+        continue-on-error: true
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          
+          # MCPサーバー設定
+          mcp_servers: |
+            {
+              "effective-yomimono-mcp": {
+                "command": "node",
+                "args": ["${{ github.workspace }}/mcp/build/index.js"],
+                "env": {
+                  "API_BASE_URL": "https://effective-yomimono-api.ryosuke-horie37.workers.dev"
+                }
+              }
+            }
+          
+          # Direct prompt for automated labeling (retry)
+          direct_prompt: |
+            【リトライ実行】MCPツールを使用して記事の自動ラベル付けを実行してください。
+            
+            環境設定：
+            - テストモード: ${{ github.event.inputs.dry_run || 'false' }}
+            - 最大処理記事数: ${{ github.event.inputs.max_articles || '制限なし' }}
+            - リトライ回数: 2回目
+            
+            以下の手順で処理を行ってください：
+            
+            1. まず、getLabels ツールを使用して既存のラベル一覧を取得してください。
+            2. 次に、getUnlabeledArticles ツールを使用してラベル付けされていない記事を取得してください。
+            3. ${{ github.event.inputs.max_articles && format('最大{0}件の記事を処理してください。', github.event.inputs.max_articles) || '全ての未ラベル記事を処理してください。' }}
+            4. 各記事に対して、タイトルと内容から最も適切なラベルを判定してください。
+            5. ${{ github.event.inputs.dry_run == 'true' && 'テストモードのため、実際のラベル付けは行わず、判定結果のみ報告してください。' || 'assignLabel ツールを使用して、判定したラベルを記事に割り当ててください。' }}
+            
+            処理結果として以下を必ず報告してください：
+            - 処理対象記事の総数
+            - 処理完了記事数
+            - エラーが発生した場合はその詳細
+            
+            ```summary
+            処理結果サマリー:
+            - 処理対象: X件
+            - 処理完了: Y件
+            - 処理失敗: Z件
+            ```
+
+      - name: Run Claude Auto Labeling (Final Retry - Attempt 3)
+        if: steps.claude-labeling-1.outcome == 'failure' && steps.claude-labeling-2.outcome == 'failure'
+        id: claude-labeling-3
+        uses: anthropics/claude-code-action@beta
+        continue-on-error: true
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          
+          # MCPサーバー設定
+          mcp_servers: |
+            {
+              "effective-yomimono-mcp": {
+                "command": "node",
+                "args": ["${{ github.workspace }}/mcp/build/index.js"],
+                "env": {
+                  "API_BASE_URL": "https://effective-yomimono-api.ryosuke-horie37.workers.dev"
+                }
+              }
+            }
+          
+          # Direct prompt for automated labeling (final retry)
+          direct_prompt: |
+            【最終リトライ実行】MCPツールを使用して記事の自動ラベル付けを実行してください。
+            
+            環境設定：
+            - テストモード: ${{ github.event.inputs.dry_run || 'false' }}
+            - 最大処理記事数: ${{ github.event.inputs.max_articles || '10' }}（最終リトライのため制限）
+            - リトライ回数: 3回目（最終）
+            
+            最小限の処理でも良いので、確実に動作させてください：
+            
+            1. getLabels ツールを使用して既存のラベル一覧を取得
+            2. getUnlabeledArticles ツールを使用して未ラベル記事を取得
+            3. 最大10件の記事のみ処理
+            4. ${{ github.event.inputs.dry_run == 'true' && 'テストモードのため、判定結果のみ報告' || 'assignLabel で記事にラベル付け' }}
+            
+            簡潔な結果報告：
+            - 処理件数: X件
+            - 成功/失敗
+
+      - name: Determine Final Status
+        id: final-status
+        run: |
+          if [[ "${{ steps.claude-labeling-1.outcome }}" == "success" ]]; then
+            echo "final_outcome=success" >> $GITHUB_OUTPUT
+            echo "attempt_count=1" >> $GITHUB_OUTPUT
+            echo "::notice::自動ラベル付けが正常に完了しました（1回目の試行で成功）"
+          elif [[ "${{ steps.claude-labeling-2.outcome }}" == "success" ]]; then
+            echo "final_outcome=success" >> $GITHUB_OUTPUT
+            echo "attempt_count=2" >> $GITHUB_OUTPUT
+            echo "::warning::自動ラベル付けが完了しました（2回目の試行で成功）"
+          elif [[ "${{ steps.claude-labeling-3.outcome }}" == "success" ]]; then
+            echo "final_outcome=success" >> $GITHUB_OUTPUT
+            echo "attempt_count=3" >> $GITHUB_OUTPUT
+            echo "::warning::自動ラベル付けが完了しました（3回目の試行で成功）"
+          else
+            echo "final_outcome=failure" >> $GITHUB_OUTPUT
+            echo "attempt_count=3" >> $GITHUB_OUTPUT
+            echo "::error::自動ラベル付けが失敗しました（3回の試行全て失敗）"
+          fi
+
+      - name: Generate Job Summary
+        if: always()
+        run: |
+          echo "# 📋 自動ラベル付け実行結果" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          
+          if [[ "${{ steps.final-status.outputs.final_outcome }}" == "success" ]]; then
+            echo "✅ **ステータス**: 成功" >> $GITHUB_STEP_SUMMARY
+            echo "🔄 **試行回数**: ${{ steps.final-status.outputs.attempt_count }}回" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "❌ **ステータス**: 失敗" >> $GITHUB_STEP_SUMMARY
+            echo "🔄 **試行回数**: 3回（全て失敗）" >> $GITHUB_STEP_SUMMARY
+          fi
+          
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "## 実行設定" >> $GITHUB_STEP_SUMMARY
+          echo "- **実行モード**: ${{ github.event_name == 'schedule' && '定期実行' || '手動実行' }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **テストモード**: ${{ github.event.inputs.dry_run || 'false' }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **最大処理記事数**: ${{ github.event.inputs.max_articles || '制限なし' }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **実行日時**: $(date '+%Y-%m-%d %H:%M:%S JST' -d '+9 hours')" >> $GITHUB_STEP_SUMMARY
+          
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "## 各試行の結果" >> $GITHUB_STEP_SUMMARY
+          echo "| 試行 | 結果 |" >> $GITHUB_STEP_SUMMARY
+          echo "|------|------|" >> $GITHUB_STEP_SUMMARY
+          echo "| 1回目 | ${{ steps.claude-labeling-1.outcome == 'success' && '✅ 成功' || steps.claude-labeling-1.outcome == 'skipped' && '⏭️ スキップ' || '❌ 失敗' }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| 2回目 | ${{ steps.claude-labeling-2.outcome == 'success' && '✅ 成功' || steps.claude-labeling-2.outcome == 'skipped' && '⏭️ スキップ' || '❌ 失敗' }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| 3回目 | ${{ steps.claude-labeling-3.outcome == 'success' && '✅ 成功' || steps.claude-labeling-3.outcome == 'skipped' && '⏭️ スキップ' || '❌ 失敗' }} |" >> $GITHUB_STEP_SUMMARY
+
+      - name: Create Issue on Failure
+        if: steps.final-status.outputs.final_outcome == 'failure' && github.event_name == 'schedule'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const title = `🚨 自動ラベル付けワークフロー失敗 - ${new Date().toISOString().split('T')[0]}`;
+            const body = `
+            ## エラー概要
+            
+            自動ラベル付けワークフローが3回の試行すべてで失敗しました。
+            
+            ### 実行情報
+            - **ワークフロー実行**: [#${{ github.run_number }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
+            - **実行日時**: ${new Date().toLocaleString('ja-JP', { timeZone: 'Asia/Tokyo' })}
+            - **トリガー**: 定期実行（毎日午前9時 JST）
+            
+            ### 対応が必要な項目
+            - [ ] エラーログの確認
+            - [ ] APIの状態確認
+            - [ ] MCP設定の確認
+            - [ ] Claude Code OAuth トークンの有効性確認
+            
+            ### 関連リンク
+            - [ワークフローファイル](${{ github.server_url }}/${{ github.repository }}/blob/main/.github/workflows/auto-labeling.yml)
+            - [実行履歴](${{ github.server_url }}/${{ github.repository }}/actions/workflows/auto-labeling.yml)
+            
+            cc: @${{ github.repository_owner }}
+            `;
+            
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: title,
+              body: body,
+              labels: ['bug', 'workflow', 'auto-labeling']
+            });
+
+      - name: Final Validation
+        if: steps.final-status.outputs.final_outcome == 'failure'
+        run: |
+          echo "::error::自動ラベル付けワークフローが失敗しました。詳細はジョブサマリーを確認してください。"
+          exit 1

--- a/mcp/src/test/apiClient.bookmarks.test.ts
+++ b/mcp/src/test/apiClient.bookmarks.test.ts
@@ -555,7 +555,7 @@ describe("Bookmark API Functions", () => {
 				json: async () => {
 					throw new Error("Invalid JSON");
 				},
-			} as Response);
+			} as unknown as Response);
 
 			await expect(apiClient.cleanupUnusedLabels()).rejects.toThrow(
 				"Failed to cleanup unused labels. Status: 500 Internal Server Error",

--- a/mcp/src/test/apiClient.bookmarks.test.ts
+++ b/mcp/src/test/apiClient.bookmarks.test.ts
@@ -1,0 +1,642 @@
+/**
+ * MCPサーバーのブックマーク関連機能のテスト
+ */
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import type { MockInstance } from "vitest";
+import * as apiClient from "../lib/apiClient.js";
+
+describe("Bookmark API Functions", () => {
+	let fetchMock: MockInstance;
+	const originalEnv = process.env.API_BASE_URL;
+
+	beforeEach(() => {
+		process.env.API_BASE_URL = "http://localhost:3000";
+		fetchMock = vi.spyOn(global, "fetch");
+	});
+
+	afterEach(() => {
+		if (originalEnv) {
+			process.env.API_BASE_URL = originalEnv;
+		} else {
+			delete process.env.API_BASE_URL;
+		}
+		vi.restoreAllMocks();
+	});
+
+	describe("getBookmarkById", () => {
+		test("正常に特定のブックマークを取得できること", async () => {
+			const mockBookmark = {
+				id: 1,
+				url: "https://example.com/article",
+				title: "Test Article",
+				isRead: false,
+				createdAt: "2024-01-01T00:00:00Z",
+				updatedAt: "2024-01-01T00:00:00Z",
+			};
+
+			fetchMock.mockResolvedValueOnce({
+				ok: true,
+				json: async () => ({
+					success: true,
+					bookmark: mockBookmark,
+				}),
+			} as Response);
+
+			const result = await apiClient.getBookmarkById(1);
+
+			expect(fetchMock).toHaveBeenCalledWith(
+				"http://localhost:3000/api/bookmarks/1",
+			);
+			expect(result).toEqual(mockBookmark);
+		});
+
+		test("存在しないブックマークIDでエラーをスローすること", async () => {
+			fetchMock.mockResolvedValueOnce({
+				ok: false,
+				statusText: "Not Found",
+			} as Response);
+
+			await expect(apiClient.getBookmarkById(999)).rejects.toThrow(
+				"Failed to fetch bookmark 999: Not Found",
+			);
+		});
+
+		test("不正なレスポンス形式でエラーをスローすること", async () => {
+			fetchMock.mockResolvedValueOnce({
+				ok: true,
+				json: async () => ({
+					// success: trueが欠けている
+					bookmark: { id: 1 },
+				}),
+			} as Response);
+
+			await expect(apiClient.getBookmarkById(1)).rejects.toThrow(
+				"Invalid API response for bookmark 1:",
+			);
+		});
+	});
+
+	describe("getUnreadArticlesByLabel", () => {
+		test("正常にラベルで未読記事を取得できること", async () => {
+			const mockArticles = [
+				{
+					id: 1,
+					title: "Tech Article 1",
+					url: "https://example.com/1",
+					isRead: false,
+					label: {
+						id: 1,
+						name: "技術記事",
+						description: "技術関連の記事",
+						createdAt: "2024-01-01T00:00:00Z",
+						updatedAt: "2024-01-01T00:00:00Z",
+					},
+					createdAt: "2024-01-01T00:00:00Z",
+					updatedAt: "2024-01-01T00:00:00Z",
+				},
+				{
+					id: 2,
+					title: "Tech Article 2",
+					url: "https://example.com/2",
+					isRead: false,
+					label: {
+						id: 1,
+						name: "技術記事",
+						description: "技術関連の記事",
+						createdAt: "2024-01-01T00:00:00Z",
+						updatedAt: "2024-01-01T00:00:00Z",
+					},
+					createdAt: "2024-01-02T00:00:00Z",
+					updatedAt: "2024-01-02T00:00:00Z",
+				},
+			];
+
+			fetchMock.mockResolvedValueOnce({
+				ok: true,
+				json: async () => ({
+					success: true,
+					bookmarks: mockArticles,
+				}),
+			} as Response);
+
+			const result = await apiClient.getUnreadArticlesByLabel("技術記事");
+
+			expect(fetchMock).toHaveBeenCalledWith(
+				"http://localhost:3000/api/bookmarks?label=%E6%8A%80%E8%A1%93%E8%A8%98%E4%BA%8B",
+			);
+			expect(result).toEqual(mockArticles);
+		});
+
+		test("特殊文字を含むラベル名が正しくエンコードされること", async () => {
+			fetchMock.mockResolvedValueOnce({
+				ok: true,
+				json: async () => ({
+					success: true,
+					bookmarks: [],
+				}),
+			} as Response);
+
+			await apiClient.getUnreadArticlesByLabel("テスト & 開発");
+
+			const callArgs = fetchMock.mock.calls[0];
+			expect(callArgs[0]).toContain("label=%E3%83%86%E3%82%B9%E3%83%88%20%26%20%E9%96%8B%E7%99%BA");
+		});
+
+		test("APIエラー時に適切なエラーをスローすること", async () => {
+			fetchMock.mockResolvedValueOnce({
+				ok: false,
+				statusText: "Bad Request",
+			} as Response);
+
+			await expect(
+				apiClient.getUnreadArticlesByLabel("無効なラベル"),
+			).rejects.toThrow(
+				'Failed to fetch unread articles for label "無効なラベル": Bad Request',
+			);
+		});
+
+		test("空のラベル名でもAPIリクエストが送信されること", async () => {
+			fetchMock.mockResolvedValueOnce({
+				ok: true,
+				json: async () => ({
+					success: true,
+					bookmarks: [],
+				}),
+			} as Response);
+
+			const result = await apiClient.getUnreadArticlesByLabel("");
+
+			expect(fetchMock).toHaveBeenCalledWith(
+				"http://localhost:3000/api/bookmarks?label=",
+			);
+			expect(result).toEqual([]);
+		});
+	});
+
+	describe("getUnreadBookmarks", () => {
+		test("正常に未読ブックマークを取得できること", async () => {
+			const mockBookmarks = [
+				{
+					id: 1,
+					title: "Unread Article 1",
+					url: "https://example.com/1",
+					isRead: false,
+					label: null,
+					createdAt: "2024-01-01T00:00:00Z",
+					updatedAt: "2024-01-01T00:00:00Z",
+				},
+				{
+					id: 2,
+					title: "Unread Article 2",
+					url: "https://example.com/2",
+					isRead: false,
+					label: {
+						id: 1,
+						name: "テスト",
+						description: null,
+						createdAt: "2024-01-01T00:00:00Z",
+						updatedAt: "2024-01-01T00:00:00Z",
+					},
+					createdAt: "2024-01-02T00:00:00Z",
+					updatedAt: "2024-01-02T00:00:00Z",
+				},
+			];
+
+			fetchMock.mockResolvedValueOnce({
+				ok: true,
+				json: async () => ({
+					success: true,
+					bookmarks: mockBookmarks,
+				}),
+			} as Response);
+
+			const result = await apiClient.getUnreadBookmarks();
+
+			expect(fetchMock).toHaveBeenCalledWith("http://localhost:3000/api/bookmarks");
+			expect(result).toHaveLength(2);
+			expect(result[0]).toMatchObject({
+				id: 1,
+				url: "https://example.com/1",
+				title: "Unread Article 1",
+				isRead: false,
+				labels: [],
+				isFavorite: false,
+				readAt: null,
+			});
+			expect(result[1]).toMatchObject({
+				id: 2,
+				url: "https://example.com/2",
+				title: "Unread Article 2",
+				isRead: false,
+				labels: ["テスト"],
+				isFavorite: false,
+				readAt: null,
+			});
+		});
+
+		test("APIエラー時に適切なエラーをスローすること", async () => {
+			fetchMock.mockResolvedValueOnce({
+				ok: false,
+				statusText: "Internal Server Error",
+			} as Response);
+
+			await expect(apiClient.getUnreadBookmarks()).rejects.toThrow(
+				"Failed to fetch unread bookmarks: Internal Server Error",
+			);
+		});
+
+		test("isFavoriteがundefinedの場合falseに変換されること", async () => {
+			const mockBookmarks = [
+				{
+					id: 1,
+					title: "Article",
+					url: "https://example.com",
+					isRead: false,
+					// isFavoriteが未定義
+					createdAt: "2024-01-01T00:00:00Z",
+					updatedAt: "2024-01-01T00:00:00Z",
+				},
+			];
+
+			fetchMock.mockResolvedValueOnce({
+				ok: true,
+				json: async () => ({
+					success: true,
+					bookmarks: mockBookmarks,
+				}),
+			} as Response);
+
+			const result = await apiClient.getUnreadBookmarks();
+			expect(result[0].isFavorite).toBe(false);
+		});
+
+		test("Dateオブジェクトの日付を文字列に変換すること", async () => {
+			const now = new Date();
+			const mockBookmarks = [
+				{
+					id: 1,
+					title: "Article",
+					url: "https://example.com",
+					isRead: false,
+					createdAt: now,
+					updatedAt: now,
+				},
+			];
+
+			fetchMock.mockResolvedValueOnce({
+				ok: true,
+				json: async () => ({
+					success: true,
+					bookmarks: mockBookmarks,
+				}),
+			} as Response);
+
+			const result = await apiClient.getUnreadBookmarks();
+			expect(result[0].createdAt).toBe(now.toISOString());
+			expect(result[0].updatedAt).toBe(now.toISOString());
+		});
+	});
+
+	describe("getReadBookmarks", () => {
+		test("正常に既読ブックマークを取得できること", async () => {
+			const mockBookmarks = [
+				{
+					id: 1,
+					url: "https://example.com/1",
+					title: "Read Article 1",
+					labels: ["技術", "JavaScript"],
+					isRead: true,
+					isFavorite: true,
+					createdAt: "2024-01-01T00:00:00Z",
+					readAt: "2024-01-05T10:00:00Z",
+					updatedAt: "2024-01-05T10:00:00Z",
+				},
+				{
+					id: 2,
+					url: "https://example.com/2",
+					title: "Read Article 2",
+					labels: [],
+					isRead: true,
+					isFavorite: false,
+					createdAt: "2024-01-02T00:00:00Z",
+					readAt: "2024-01-06T10:00:00Z",
+					updatedAt: "2024-01-06T10:00:00Z",
+				},
+			];
+
+			fetchMock.mockResolvedValueOnce({
+				ok: true,
+				json: async () => ({
+					success: true,
+					bookmarks: mockBookmarks,
+				}),
+			} as Response);
+
+			const result = await apiClient.getReadBookmarks();
+
+			expect(fetchMock).toHaveBeenCalledWith(
+				"http://localhost:3000/api/bookmarks/read",
+			);
+			expect(result).toEqual(mockBookmarks);
+		});
+
+		test("APIエラー時に適切なエラーをスローすること", async () => {
+			fetchMock.mockResolvedValueOnce({
+				ok: false,
+				statusText: "Service Unavailable",
+			} as Response);
+
+			await expect(apiClient.getReadBookmarks()).rejects.toThrow(
+				"Failed to fetch read bookmarks: Service Unavailable",
+			);
+		});
+
+		test("不正なレスポンス形式でエラーをスローすること", async () => {
+			fetchMock.mockResolvedValueOnce({
+				ok: true,
+				json: async () => ({
+					success: true,
+					// bookmarksではなくitemsというキー
+					items: [],
+				}),
+			} as Response);
+
+			await expect(apiClient.getReadBookmarks()).rejects.toThrow(
+				"Invalid API response for read bookmarks:",
+			);
+		});
+
+		test("labelsがundefinedの場合空配列に変換されること", async () => {
+			const mockBookmarks = [
+				{
+					id: 1,
+					url: "https://example.com",
+					title: "Article",
+					// labelsが未定義
+					isRead: true,
+					createdAt: "2024-01-01T00:00:00Z",
+					readAt: "2024-01-05T10:00:00Z",
+				},
+			];
+
+			fetchMock.mockResolvedValueOnce({
+				ok: true,
+				json: async () => ({
+					success: true,
+					bookmarks: mockBookmarks,
+				}),
+			} as Response);
+
+			const result = await apiClient.getReadBookmarks();
+			expect(result[0].labels).toEqual([]);
+		});
+
+		test("isFavoriteがundefinedの場合falseに変換されること", async () => {
+			const mockBookmarks = [
+				{
+					id: 1,
+					url: "https://example.com",
+					title: "Article",
+					labels: ["test"],
+					isRead: true,
+					// isFavoriteが未定義
+					createdAt: "2024-01-01T00:00:00Z",
+					readAt: "2024-01-05T10:00:00Z",
+				},
+			];
+
+			fetchMock.mockResolvedValueOnce({
+				ok: true,
+				json: async () => ({
+					success: true,
+					bookmarks: mockBookmarks,
+				}),
+			} as Response);
+
+			const result = await apiClient.getReadBookmarks();
+			expect(result[0].isFavorite).toBe(false);
+		});
+	});
+
+	describe("markBookmarkAsRead", () => {
+		test("正常にブックマークを既読にマークできること", async () => {
+			fetchMock.mockResolvedValueOnce({
+				ok: true,
+				json: async () => ({
+					success: true,
+					message: "Bookmark marked as read successfully",
+				}),
+			} as Response);
+
+			const result = await apiClient.markBookmarkAsRead(1);
+
+			expect(fetchMock).toHaveBeenCalledWith(
+				"http://localhost:3000/api/bookmarks/1/read",
+				{
+					method: "PATCH",
+				},
+			);
+			expect(result).toEqual({
+				success: true,
+				message: "Bookmark marked as read successfully",
+			});
+		});
+
+		test("存在しないブックマークIDでエラーをスローすること", async () => {
+			fetchMock.mockResolvedValueOnce({
+				ok: false,
+				statusText: "Not Found",
+			} as Response);
+
+			await expect(apiClient.markBookmarkAsRead(999)).rejects.toThrow(
+				"Failed to mark bookmark 999 as read: Not Found",
+			);
+		});
+
+		test("既に既読のブックマークでも成功すること", async () => {
+			fetchMock.mockResolvedValueOnce({
+				ok: true,
+				json: async () => ({
+					success: true,
+					message: "Bookmark already marked as read",
+				}),
+			} as Response);
+
+			const result = await apiClient.markBookmarkAsRead(1);
+
+			expect(result.message).toBe("Bookmark already marked as read");
+		});
+
+		test("不正なレスポンス形式でエラーをスローすること", async () => {
+			fetchMock.mockResolvedValueOnce({
+				ok: true,
+				json: async () => ({
+					// success: trueが欠けている
+					message: "Bookmark marked as read",
+				}),
+			} as Response);
+
+			await expect(apiClient.markBookmarkAsRead(1)).rejects.toThrow(
+				"Invalid API response after marking bookmark as read:",
+			);
+		});
+	});
+
+	describe("cleanupUnusedLabels", () => {
+		test("正常に未使用ラベルをクリーンアップできること", async () => {
+			const mockResponse = {
+				success: true,
+				message: "Cleanup completed successfully",
+				deletedCount: 3,
+				deletedLabels: [
+					{ id: 1, name: "未使用1" },
+					{ id: 2, name: "未使用2" },
+					{ id: 3, name: "未使用3" },
+				],
+			};
+
+			fetchMock.mockResolvedValueOnce({
+				ok: true,
+				json: async () => mockResponse,
+			} as Response);
+
+			const result = await apiClient.cleanupUnusedLabels();
+
+			expect(fetchMock).toHaveBeenCalledWith(
+				"http://localhost:3000/api/labels/cleanup",
+				{
+					method: "DELETE",
+				},
+			);
+			expect(result).toEqual({
+				deletedCount: 3,
+				deletedLabels: mockResponse.deletedLabels,
+				message: "Cleanup completed successfully",
+			});
+		});
+
+		test("削除対象がない場合も正常に処理できること", async () => {
+			fetchMock.mockResolvedValueOnce({
+				ok: true,
+				json: async () => ({
+					success: true,
+					message: "No unused labels found",
+					deletedCount: 0,
+					deletedLabels: [],
+				}),
+			} as Response);
+
+			const result = await apiClient.cleanupUnusedLabels();
+
+			expect(result.deletedCount).toBe(0);
+			expect(result.deletedLabels).toEqual([]);
+		});
+
+		test("APIエラー時に適切なエラーをスローすること", async () => {
+			fetchMock.mockResolvedValueOnce({
+				ok: false,
+				status: 500,
+				statusText: "Internal Server Error",
+				json: async () => ({
+					message: "Database error during cleanup",
+				}),
+			} as Response);
+
+			await expect(apiClient.cleanupUnusedLabels()).rejects.toThrow(
+				"Database error during cleanup: Internal Server Error (Status: 500)",
+			);
+		});
+
+		test("JSONパースエラー時に適切なエラーをスローすること", async () => {
+			fetchMock.mockResolvedValueOnce({
+				ok: false,
+				status: 500,
+				statusText: "Internal Server Error",
+				json: async () => {
+					throw new Error("Invalid JSON");
+				},
+			} as Response);
+
+			await expect(apiClient.cleanupUnusedLabels()).rejects.toThrow(
+				"Failed to cleanup unused labels. Status: 500 Internal Server Error",
+			);
+		});
+
+		test("不正なレスポンス形式でエラーをスローすること", async () => {
+			fetchMock.mockResolvedValueOnce({
+				ok: true,
+				json: async () => ({
+					success: true,
+					// requiredフィールドが欠けている
+					message: "Cleanup completed",
+				}),
+			} as Response);
+
+			await expect(apiClient.cleanupUnusedLabels()).rejects.toThrow(
+				"Invalid API response after cleaning up labels. Zod errors:",
+			);
+		});
+	});
+
+	describe("複数API呼び出しの組み合わせ", () => {
+		test("ブックマークを取得して既読にマークするフロー", async () => {
+			// 1. 未読ブックマークを取得
+			fetchMock.mockResolvedValueOnce({
+				ok: true,
+				json: async () => ({
+					success: true,
+					bookmarks: [
+						{
+							id: 1,
+							title: "Article",
+							url: "https://example.com",
+							isRead: false,
+							createdAt: "2024-01-01T00:00:00Z",
+							updatedAt: "2024-01-01T00:00:00Z",
+						},
+					],
+				}),
+			} as Response);
+
+			const unreadBookmarks = await apiClient.getUnreadBookmarks();
+			expect(unreadBookmarks).toHaveLength(1);
+
+			// 2. ブックマークを既読にマーク
+			fetchMock.mockResolvedValueOnce({
+				ok: true,
+				json: async () => ({
+					success: true,
+					message: "Marked as read",
+				}),
+			} as Response);
+
+			await apiClient.markBookmarkAsRead(unreadBookmarks[0].id);
+
+			// 3. 既読ブックマークを取得して確認
+			fetchMock.mockResolvedValueOnce({
+				ok: true,
+				json: async () => ({
+					success: true,
+					bookmarks: [
+						{
+							id: 1,
+							url: "https://example.com",
+							title: "Article",
+							labels: [],
+							isRead: true,
+							isFavorite: false,
+							createdAt: "2024-01-01T00:00:00Z",
+							readAt: "2024-01-05T10:00:00Z",
+							updatedAt: "2024-01-05T10:00:00Z",
+						},
+					],
+				}),
+			} as Response);
+
+			const readBookmarks = await apiClient.getReadBookmarks();
+			expect(readBookmarks).toHaveLength(1);
+			expect(readBookmarks[0].isRead).toBe(true);
+			expect(readBookmarks[0].readAt).toBeDefined();
+		});
+	});
+});

--- a/mcp/src/test/apiClient.edge-cases.test.ts
+++ b/mcp/src/test/apiClient.edge-cases.test.ts
@@ -1,0 +1,599 @@
+/**
+ * MCPサーバーのエッジケースと境界値テスト
+ */
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import type { MockInstance } from "vitest";
+import * as apiClient from "../lib/apiClient.js";
+
+describe("Edge Cases and Boundary Value Tests", () => {
+	let fetchMock: MockInstance;
+	const originalEnv = process.env.API_BASE_URL;
+
+	beforeEach(() => {
+		process.env.API_BASE_URL = "http://localhost:3000";
+		fetchMock = vi.spyOn(global, "fetch");
+	});
+
+	afterEach(() => {
+		if (originalEnv) {
+			process.env.API_BASE_URL = originalEnv;
+		} else {
+			delete process.env.API_BASE_URL;
+		}
+		vi.restoreAllMocks();
+	});
+
+	describe("assignLabelsToMultipleArticles - 境界値とエッジケース", () => {
+		test("非常に大きな記事ID配列を処理できること", async () => {
+			// 1000個の記事IDを生成
+			const largeArticleIds = Array.from({ length: 1000 }, (_, i) => i + 1);
+
+			fetchMock.mockResolvedValueOnce({
+				ok: true,
+				json: async () => ({
+					success: true,
+					successful: 900,
+					skipped: 50,
+					errors: Array.from({ length: 50 }, (_, i) => ({
+						articleId: i + 951,
+						error: "Article not found",
+					})),
+					label: {
+						id: 1,
+						name: "大量処理",
+						description: null,
+						createdAt: "2024-01-01T00:00:00Z",
+						updatedAt: "2024-01-01T00:00:00Z",
+					},
+				}),
+			} as Response);
+
+			const result = await apiClient.assignLabelsToMultipleArticles(
+				largeArticleIds,
+				"大量処理",
+			);
+
+			expect(result.successful).toBe(900);
+			expect(result.skipped).toBe(50);
+			expect(result.errors).toHaveLength(50);
+		});
+
+		test("単一要素の配列を正しく処理できること", async () => {
+			fetchMock.mockResolvedValueOnce({
+				ok: true,
+				json: async () => ({
+					success: true,
+					successful: 1,
+					skipped: 0,
+					errors: [],
+					label: {
+						id: 1,
+						name: "単一",
+						description: null,
+						createdAt: "2024-01-01T00:00:00Z",
+						updatedAt: "2024-01-01T00:00:00Z",
+					},
+				}),
+			} as Response);
+
+			const result = await apiClient.assignLabelsToMultipleArticles(
+				[42],
+				"単一",
+			);
+
+			expect(result.successful).toBe(1);
+			expect(result.errors).toEqual([]);
+		});
+
+		test("すべての記事が既にラベル付けされている場合", async () => {
+			fetchMock.mockResolvedValueOnce({
+				ok: true,
+				json: async () => ({
+					success: true,
+					successful: 0,
+					skipped: 5,
+					errors: [],
+					label: {
+						id: 1,
+						name: "既存",
+						description: null,
+						createdAt: "2024-01-01T00:00:00Z",
+						updatedAt: "2024-01-01T00:00:00Z",
+					},
+				}),
+			} as Response);
+
+			const result = await apiClient.assignLabelsToMultipleArticles(
+				[1, 2, 3, 4, 5],
+				"既存",
+			);
+
+			expect(result.successful).toBe(0);
+			expect(result.skipped).toBe(5);
+		});
+
+		test("すべての記事IDが無効な場合", async () => {
+			fetchMock.mockResolvedValueOnce({
+				ok: true,
+				json: async () => ({
+					success: true,
+					successful: 0,
+					skipped: 0,
+					errors: [
+						{ articleId: -1, error: "Invalid article ID" },
+						{ articleId: -2, error: "Invalid article ID" },
+						{ articleId: 0, error: "Invalid article ID" },
+					],
+					label: {
+						id: 1,
+						name: "無効",
+						description: null,
+						createdAt: "2024-01-01T00:00:00Z",
+						updatedAt: "2024-01-01T00:00:00Z",
+					},
+				}),
+			} as Response);
+
+			const result = await apiClient.assignLabelsToMultipleArticles(
+				[-1, -2, 0],
+				"無効",
+			);
+
+			expect(result.successful).toBe(0);
+			expect(result.errors).toHaveLength(3);
+		});
+	});
+
+	describe("ラベル名の特殊ケース", () => {
+		test("非常に長いラベル名を処理できること", async () => {
+			const longLabelName = "あ".repeat(255); // 255文字のラベル名
+
+			fetchMock.mockResolvedValueOnce({
+				ok: true,
+				headers: new Headers({ "content-type": "application/json" }),
+				json: async () => ({
+					success: true,
+					label: {
+						id: 1,
+						name: longLabelName,
+						description: null,
+						createdAt: "2024-01-01T00:00:00Z",
+						updatedAt: "2024-01-01T00:00:00Z",
+					},
+				}),
+			} as Response);
+
+			const result = await apiClient.createLabel(longLabelName);
+			expect(result.name).toBe(longLabelName);
+		});
+
+		test("特殊文字を含むラベル名を処理できること", async () => {
+			const specialChars = [
+				"テスト#1",
+				"テスト@2",
+				"テスト$3",
+				"テスト%4",
+				"テスト&5",
+				"テスト*6",
+				"テスト(7)",
+				"テスト[8]",
+				"テスト{9}",
+				'テスト"10"',
+				"テスト'11'",
+				"テスト<12>",
+				"テスト=13",
+				"テスト+14",
+				"テスト-15",
+				"テスト_16",
+				"テスト.17",
+				"テスト,18",
+				"テスト;19",
+				"テスト:20",
+				"テスト/21",
+				"テスト\\22",
+				"テスト|23",
+				"テスト?24",
+				"テスト!25",
+				"テスト~26",
+				"テスト`27",
+				"テスト^28",
+				"テスト 空白 29",
+				"テスト\tタブ30",
+				"テスト\n改行31",
+			];
+
+			for (const labelName of specialChars) {
+				fetchMock.mockResolvedValueOnce({
+					ok: true,
+					headers: new Headers({ "content-type": "application/json" }),
+					json: async () => ({
+						success: true,
+						label: {
+							id: 1,
+							name: labelName,
+							description: null,
+							createdAt: "2024-01-01T00:00:00Z",
+							updatedAt: "2024-01-01T00:00:00Z",
+						},
+					}),
+				} as Response);
+
+				const result = await apiClient.createLabel(labelName);
+				expect(result.name).toBe(labelName);
+			}
+		});
+
+		test("絵文字を含むラベル名を処理できること", async () => {
+			const emojiLabels = [
+				"📚 読書",
+				"🔧 技術",
+				"📰 ニュース",
+				"🎯 重要",
+				"⭐ お気に入り",
+				"🚀 新機能",
+				"🐛 バグ",
+				"💡 アイデア",
+				"🌟✨💫 複数絵文字",
+			];
+
+			for (const labelName of emojiLabels) {
+				fetchMock.mockResolvedValueOnce({
+					ok: true,
+					headers: new Headers({ "content-type": "application/json" }),
+					json: async () => ({
+						success: true,
+						label: {
+							id: 1,
+							name: labelName,
+							description: null,
+							createdAt: "2024-01-01T00:00:00Z",
+							updatedAt: "2024-01-01T00:00:00Z",
+						},
+					}),
+				} as Response);
+
+				const result = await apiClient.createLabel(labelName);
+				expect(result.name).toBe(labelName);
+			}
+		});
+
+		test("Unicode文字を含むラベル名を処理できること", async () => {
+			const unicodeLabels = [
+				"中文标签", // 中国語
+				"한글라벨", // 韓国語
+				"العربية", // アラビア語
+				"ไทย", // タイ語
+				"עברית", // ヘブライ語
+				"Ελληνικά", // ギリシャ語
+				"Русский", // ロシア語
+				"日本語ラベル", // 日本語
+			];
+
+			for (const labelName of unicodeLabels) {
+				fetchMock.mockResolvedValueOnce({
+					ok: true,
+					headers: new Headers({ "content-type": "application/json" }),
+					json: async () => ({
+						success: true,
+						label: {
+							id: 1,
+							name: labelName,
+							description: null,
+							createdAt: "2024-01-01T00:00:00Z",
+							updatedAt: "2024-01-01T00:00:00Z",
+						},
+					}),
+				} as Response);
+
+				const result = await apiClient.createLabel(labelName);
+				expect(result.name).toBe(labelName);
+			}
+		});
+	});
+
+	describe("説明フィールドの境界値", () => {
+		test("非常に長い説明を処理できること", async () => {
+			const longDescription = "説明".repeat(2000); // 4000文字の説明
+
+			fetchMock.mockResolvedValueOnce({
+				ok: true,
+				headers: new Headers({ "content-type": "application/json" }),
+				json: async () => ({
+					success: true,
+					label: {
+						id: 1,
+						name: "テスト",
+						description: longDescription,
+						createdAt: "2024-01-01T00:00:00Z",
+						updatedAt: "2024-01-01T00:00:00Z",
+					},
+				}),
+			} as Response);
+
+			const result = await apiClient.createLabel("テスト", longDescription);
+			expect(result.description).toBe(longDescription);
+		});
+
+		test("空文字列の説明を処理できること", async () => {
+			fetchMock.mockResolvedValueOnce({
+				ok: true,
+				headers: new Headers({ "content-type": "application/json" }),
+				json: async () => ({
+					success: true,
+					label: {
+						id: 1,
+						name: "テスト",
+						description: "",
+						createdAt: "2024-01-01T00:00:00Z",
+						updatedAt: "2024-01-01T00:00:00Z",
+					},
+				}),
+			} as Response);
+
+			const result = await apiClient.createLabel("テスト", "");
+			expect(result.description).toBe("");
+		});
+
+		test("スペースのみの説明を処理できること", async () => {
+			const spacesOnly = "   ";
+
+			fetchMock.mockResolvedValueOnce({
+				ok: true,
+				headers: new Headers({ "content-type": "application/json" }),
+				json: async () => ({
+					success: true,
+					label: {
+						id: 1,
+						name: "テスト",
+						description: spacesOnly,
+						createdAt: "2024-01-01T00:00:00Z",
+						updatedAt: "2024-01-01T00:00:00Z",
+					},
+				}),
+			} as Response);
+
+			const result = await apiClient.createLabel("テスト", spacesOnly);
+			expect(result.description).toBe(spacesOnly);
+		});
+	});
+
+	describe("数値境界値のテスト", () => {
+		test("最大整数値のIDを処理できること", async () => {
+			const maxId = Number.MAX_SAFE_INTEGER;
+
+			fetchMock.mockResolvedValueOnce({
+				ok: true,
+				json: async () => ({
+					success: true,
+					label: {
+						id: maxId,
+						name: "最大ID",
+						description: null,
+						createdAt: "2024-01-01T00:00:00Z",
+						updatedAt: "2024-01-01T00:00:00Z",
+					},
+				}),
+			} as Response);
+
+			const result = await apiClient.getLabelById(maxId);
+			expect(result.id).toBe(maxId);
+		});
+
+		test("ゼロのIDを処理できること", async () => {
+			fetchMock.mockResolvedValueOnce({
+				ok: true,
+				json: async () => ({
+					success: true,
+					label: {
+						id: 0,
+						name: "ゼロID",
+						description: null,
+						createdAt: "2024-01-01T00:00:00Z",
+						updatedAt: "2024-01-01T00:00:00Z",
+					},
+				}),
+			} as Response);
+
+			const result = await apiClient.getLabelById(0);
+			expect(result.id).toBe(0);
+		});
+
+		test("負のIDでもAPIリクエストは送信されること", async () => {
+			fetchMock.mockResolvedValueOnce({
+				ok: false,
+				statusText: "Bad Request",
+			} as Response);
+
+			await expect(apiClient.getLabelById(-1)).rejects.toThrow(
+				"Failed to fetch label with ID -1: Bad Request",
+			);
+
+			expect(fetchMock).toHaveBeenCalledWith(
+				"http://localhost:3000/api/labels/-1",
+			);
+		});
+	});
+
+	describe("日付フィールドの処理", () => {
+		test("様々な日付形式を処理できること", async () => {
+			const dateFormats = [
+				"2024-01-01T00:00:00Z",
+				"2024-01-01T00:00:00.000Z",
+				"2024-01-01T00:00:00+09:00",
+				"2024-01-01T00:00:00-05:00",
+				"2024-12-31T23:59:59Z",
+			];
+
+			for (const dateFormat of dateFormats) {
+				fetchMock.mockResolvedValueOnce({
+					ok: true,
+					json: async () => ({
+						success: true,
+						labels: [
+							{
+								id: 1,
+								name: "テスト",
+								description: null,
+								createdAt: dateFormat,
+								updatedAt: dateFormat,
+							},
+						],
+					}),
+				} as Response);
+
+				const result = await apiClient.getLabels();
+				expect(result[0].createdAt).toBe(dateFormat);
+				expect(result[0].updatedAt).toBe(dateFormat);
+			}
+		});
+
+		test("Dateオブジェクトとして返される日付を処理できること", async () => {
+			const now = new Date();
+
+			fetchMock.mockResolvedValueOnce({
+				ok: true,
+				json: async () => ({
+					success: true,
+					labels: [
+						{
+							id: 1,
+							name: "テスト",
+							description: null,
+							createdAt: now,
+							updatedAt: now,
+						},
+					],
+				}),
+			} as Response);
+
+			const result = await apiClient.getLabels();
+			expect(result[0].createdAt).toEqual(now);
+			expect(result[0].updatedAt).toEqual(now);
+		});
+	});
+
+	describe("レスポンスの異常パターン", () => {
+		test("予期しない追加フィールドがあっても処理できること", async () => {
+			fetchMock.mockResolvedValueOnce({
+				ok: true,
+				json: async () => ({
+					success: true,
+					labels: [
+						{
+							id: 1,
+							name: "テスト",
+							description: null,
+							createdAt: "2024-01-01T00:00:00Z",
+							updatedAt: "2024-01-01T00:00:00Z",
+							unexpectedField: "予期しない値",
+							anotherField: 12345,
+						},
+					],
+					extraData: "追加データ",
+				}),
+			} as Response);
+
+			const result = await apiClient.getLabels();
+			expect(result[0].id).toBe(1);
+			expect(result[0].name).toBe("テスト");
+			// 追加フィールドは無視される
+		});
+
+		test("部分的に不正なデータが含まれる配列を処理できること", async () => {
+			fetchMock.mockResolvedValueOnce({
+				ok: true,
+				json: async () => ({
+					success: true,
+					successful: 2,
+					skipped: 1,
+					errors: [
+						{ articleId: "文字列ID", error: "Invalid ID" }, // 本来はnumberであるべき
+						{ articleId: 2, error: "Valid error" },
+						{ articleId: null, error: "Null ID" }, // nullのID
+					],
+					label: {
+						id: 1,
+						name: "テスト",
+						description: null,
+						createdAt: "2024-01-01T00:00:00Z",
+						updatedAt: "2024-01-01T00:00:00Z",
+					},
+				}),
+			} as Response);
+
+			// Zodバリデーションでエラーになるはず
+			await expect(
+				apiClient.assignLabelsToMultipleArticles([1, 2, 3], "テスト"),
+			).rejects.toThrow("Invalid API response");
+		});
+	});
+
+	describe("ネットワークエラーと再試行", () => {
+		test("ネットワークタイムアウトを適切に処理すること", async () => {
+			fetchMock.mockImplementation(
+				() =>
+					new Promise((_, reject) => {
+						setTimeout(() => reject(new Error("Network timeout")), 100);
+					}),
+			);
+
+			await expect(apiClient.getLabels()).rejects.toThrow("Network timeout");
+		});
+
+		test("接続拒否エラーを適切に処理すること", async () => {
+			fetchMock.mockRejectedValueOnce(new Error("ECONNREFUSED"));
+
+			await expect(apiClient.getUnlabeledArticles()).rejects.toThrow(
+				"ECONNREFUSED",
+			);
+		});
+
+		test("DNSエラーを適切に処理すること", async () => {
+			fetchMock.mockRejectedValueOnce(new Error("ENOTFOUND"));
+
+			await expect(apiClient.createLabel("test")).rejects.toThrow("ENOTFOUND");
+		});
+	});
+
+	describe("Content-Typeの処理", () => {
+		test("Content-Typeがない場合でも処理できること", async () => {
+			fetchMock.mockResolvedValueOnce({
+				ok: true,
+				headers: new Headers(), // Content-Typeなし
+				json: async () => ({
+					success: true,
+					label: {
+						id: 1,
+						name: "テスト",
+						description: null,
+						createdAt: "2024-01-01T00:00:00Z",
+						updatedAt: "2024-01-01T00:00:00Z",
+					},
+				}),
+			} as Response);
+
+			const result = await apiClient.createLabel("テスト");
+			expect(result.name).toBe("テスト");
+		});
+
+		test("誤ったContent-Typeでも処理を試みること", async () => {
+			fetchMock.mockResolvedValueOnce({
+				ok: true,
+				headers: new Headers({ "content-type": "text/plain" }),
+				json: async () => ({
+					success: true,
+					label: {
+						id: 1,
+						name: "テスト",
+						description: null,
+						createdAt: "2024-01-01T00:00:00Z",
+						updatedAt: "2024-01-01T00:00:00Z",
+					},
+				}),
+			} as Response);
+
+			const result = await apiClient.createLabel("テスト");
+			expect(result.name).toBe("テスト");
+		});
+	});
+});

--- a/mcp/src/test/apiClient.integration.test.ts
+++ b/mcp/src/test/apiClient.integration.test.ts
@@ -1,0 +1,610 @@
+/**
+ * MCPサーバーのラベル関連機能の統合テスト
+ * モックAPIサーバーとの連携をシミュレート
+ */
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import type { MockInstance } from "vitest";
+import * as apiClient from "../lib/apiClient.js";
+
+describe("Label API Integration Tests", () => {
+	let fetchMock: MockInstance;
+	const originalEnv = process.env.API_BASE_URL;
+
+	// モックデータストア（実際のAPIの動作をシミュレート）
+	let mockLabels: Map<
+		number,
+		{
+			id: number;
+			name: string;
+			description: string | null;
+			createdAt: string;
+			updatedAt: string;
+		}
+	>;
+	let mockArticles: Map<
+		number,
+		{
+			id: number;
+			title: string;
+			url: string;
+			isRead: boolean;
+			labelId: number | null;
+			createdAt: string;
+			updatedAt: string;
+		}
+	>;
+	let nextLabelId: number;
+	let nextArticleId: number;
+
+	beforeEach(() => {
+		// 環境変数をモック
+		process.env.API_BASE_URL = "http://localhost:3000";
+
+		// モックデータの初期化
+		mockLabels = new Map();
+		mockArticles = new Map();
+		nextLabelId = 1;
+		nextArticleId = 1;
+
+		// 初期データを追加
+		const initialArticles = [
+			{
+				id: nextArticleId++,
+				title: "Article 1",
+				url: "https://example.com/1",
+				isRead: false,
+				labelId: null,
+				createdAt: "2024-01-01T00:00:00Z",
+				updatedAt: "2024-01-01T00:00:00Z",
+			},
+			{
+				id: nextArticleId++,
+				title: "Article 2",
+				url: "https://example.com/2",
+				isRead: false,
+				labelId: null,
+				createdAt: "2024-01-02T00:00:00Z",
+				updatedAt: "2024-01-02T00:00:00Z",
+			},
+			{
+				id: nextArticleId++,
+				title: "Article 3",
+				url: "https://example.com/3",
+				isRead: true,
+				labelId: null,
+				createdAt: "2024-01-03T00:00:00Z",
+				updatedAt: "2024-01-03T00:00:00Z",
+			},
+		];
+
+		initialArticles.forEach((article) => {
+			mockArticles.set(article.id, article);
+		});
+
+		// fetchをモック化して実際のAPIの動作をシミュレート
+		fetchMock = vi.spyOn(global, "fetch");
+		fetchMock.mockImplementation(async (url: string, options?: RequestInit) => {
+			const urlStr = url.toString();
+			const method = options?.method || "GET";
+
+			// ラベル一覧取得
+			if (urlStr.endsWith("/api/labels") && method === "GET") {
+				return {
+					ok: true,
+					json: async () => ({
+						success: true,
+						labels: Array.from(mockLabels.values()),
+					}),
+				} as Response;
+			}
+
+			// ラベル作成
+			if (urlStr.endsWith("/api/labels") && method === "POST") {
+				const body = JSON.parse(options?.body as string);
+				const existingLabel = Array.from(mockLabels.values()).find(
+					(l) => l.name === body.name,
+				);
+
+				if (existingLabel) {
+					return {
+						ok: false,
+						status: 409,
+						statusText: "Conflict",
+						headers: new Headers({ "content-type": "application/json" }),
+						json: async () => ({
+							message: "Label already exists",
+						}),
+					} as Response;
+				}
+
+				const newLabel = {
+					id: nextLabelId++,
+					name: body.name,
+					description: body.description || null,
+					createdAt: new Date().toISOString(),
+					updatedAt: new Date().toISOString(),
+				};
+				mockLabels.set(newLabel.id, newLabel);
+
+				return {
+					ok: true,
+					headers: new Headers({ "content-type": "application/json" }),
+					json: async () => ({
+						success: true,
+						label: newLabel,
+					}),
+				} as Response;
+			}
+
+			// ラベル取得（ID指定）
+			const labelByIdMatch = urlStr.match(/\/api\/labels\/(\d+)$/);
+			if (labelByIdMatch && method === "GET") {
+				const labelId = Number.parseInt(labelByIdMatch[1]);
+				const label = mockLabels.get(labelId);
+
+				if (!label) {
+					return {
+						ok: false,
+						statusText: "Not Found",
+					} as Response;
+				}
+
+				return {
+					ok: true,
+					json: async () => ({
+						success: true,
+						label,
+					}),
+				} as Response;
+			}
+
+			// ラベル更新（説明のみ）
+			if (labelByIdMatch && method === "PATCH") {
+				const labelId = Number.parseInt(labelByIdMatch[1]);
+				const label = mockLabels.get(labelId);
+
+				if (!label) {
+					return {
+						ok: false,
+						statusText: "Not Found",
+					} as Response;
+				}
+
+				const body = JSON.parse(options?.body as string);
+				label.description = body.description;
+				label.updatedAt = new Date().toISOString();
+
+				return {
+					ok: true,
+					json: async () => ({
+						success: true,
+						label,
+					}),
+				} as Response;
+			}
+
+			// ラベル削除
+			if (labelByIdMatch && method === "DELETE") {
+				const labelId = Number.parseInt(labelByIdMatch[1]);
+				const label = mockLabels.get(labelId);
+
+				if (!label) {
+					return {
+						ok: false,
+						status: 404,
+						statusText: "Not Found",
+						json: async () => ({
+							message: "Label not found",
+						}),
+					} as Response;
+				}
+
+				// 使用中のラベルかチェック
+				const isInUse = Array.from(mockArticles.values()).some(
+					(a) => a.labelId === labelId,
+				);
+				if (isInUse) {
+					return {
+						ok: false,
+						status: 409,
+						statusText: "Conflict",
+						json: async () => ({
+							message: "Cannot delete label: still in use",
+						}),
+					} as Response;
+				}
+
+				mockLabels.delete(labelId);
+
+				return {
+					ok: true,
+					json: async () => ({
+						success: true,
+						message: "Label deleted successfully",
+					}),
+				} as Response;
+			}
+
+			// 未ラベル記事取得
+			if (urlStr.endsWith("/api/bookmarks/unlabeled") && method === "GET") {
+				const unlabeledArticles = Array.from(mockArticles.values())
+					.filter((a) => a.labelId === null)
+					.map(({ labelId, ...article }) => article); // labelIdを除外
+
+				return {
+					ok: true,
+					json: async () => ({
+						success: true,
+						bookmarks: unlabeledArticles,
+					}),
+				} as Response;
+			}
+
+			// 記事にラベル割り当て
+			const assignLabelMatch = urlStr.match(/\/api\/bookmarks\/(\d+)\/label$/);
+			if (assignLabelMatch && method === "PUT") {
+				const articleId = Number.parseInt(assignLabelMatch[1]);
+				const article = mockArticles.get(articleId);
+
+				if (!article) {
+					return {
+						ok: false,
+						statusText: "Not Found",
+					} as Response;
+				}
+
+				const body = JSON.parse(options?.body as string);
+				let label = Array.from(mockLabels.values()).find(
+					(l) => l.name === body.labelName,
+				);
+
+				// ラベルが存在しない場合は作成
+				if (!label) {
+					label = {
+						id: nextLabelId++,
+						name: body.labelName,
+						description: body.description || null,
+						createdAt: new Date().toISOString(),
+						updatedAt: new Date().toISOString(),
+					};
+					mockLabels.set(label.id, label);
+				}
+
+				article.labelId = label.id;
+				article.updatedAt = new Date().toISOString();
+
+				return {
+					ok: true,
+					json: async () => ({ success: true }),
+				} as Response;
+			}
+
+			// 複数記事へのラベル一括割り当て
+			if (urlStr.endsWith("/api/bookmarks/batch-label") && method === "PUT") {
+				const body = JSON.parse(options?.body as string);
+				const { articleIds, labelName, description } = body;
+
+				// ラベルを取得または作成
+				let label = Array.from(mockLabels.values()).find(
+					(l) => l.name === labelName,
+				);
+
+				if (!label) {
+					label = {
+						id: nextLabelId++,
+						name: labelName,
+						description: description || null,
+						createdAt: new Date().toISOString(),
+						updatedAt: new Date().toISOString(),
+					};
+					mockLabels.set(label.id, label);
+				}
+
+				let successful = 0;
+				let skipped = 0;
+				const errors: Array<{ articleId: number; error: string }> = [];
+
+				for (const articleId of articleIds) {
+					const article = mockArticles.get(articleId);
+
+					if (!article) {
+						errors.push({
+							articleId,
+							error: "Article not found",
+						});
+					} else if (article.labelId === label.id) {
+						skipped++;
+					} else {
+						article.labelId = label.id;
+						article.updatedAt = new Date().toISOString();
+						successful++;
+					}
+				}
+
+				return {
+					ok: true,
+					json: async () => ({
+						success: true,
+						successful,
+						skipped,
+						errors,
+						label,
+					}),
+				} as Response;
+			}
+
+			// デフォルトのレスポンス
+			return {
+				ok: false,
+				statusText: "Not Found",
+				json: async () => ({ message: "Endpoint not found" }),
+			} as Response;
+		});
+	});
+
+	afterEach(() => {
+		// 環境変数を復元
+		if (originalEnv) {
+			process.env.API_BASE_URL = originalEnv;
+		} else {
+			delete process.env.API_BASE_URL;
+		}
+		// モックをリセット
+		vi.restoreAllMocks();
+	});
+
+	describe("ラベル作成と記事への割り当てフロー", () => {
+		test("新規ラベルを作成して記事に割り当てるワークフロー", async () => {
+			// 1. 初期状態：ラベルが存在しない
+			const initialLabels = await apiClient.getLabels();
+			expect(initialLabels).toEqual([]);
+
+			// 2. 未ラベル記事を取得
+			const unlabeledArticles = await apiClient.getUnlabeledArticles();
+			expect(unlabeledArticles.length).toBeGreaterThan(0);
+
+			// 3. 新しいラベルを作成
+			const newLabel = await apiClient.createLabel(
+				"技術記事",
+				"技術関連の記事",
+			);
+			expect(newLabel.name).toBe("技術記事");
+			expect(newLabel.id).toBeDefined();
+
+			// 4. 作成したラベルが一覧に含まれることを確認
+			const labelsAfterCreate = await apiClient.getLabels();
+			expect(labelsAfterCreate).toHaveLength(1);
+			expect(labelsAfterCreate[0].name).toBe("技術記事");
+
+			// 5. 記事にラベルを割り当て
+			await apiClient.assignLabelToArticle(
+				unlabeledArticles[0].id,
+				"技術記事",
+			);
+
+			// 6. 未ラベル記事が減っていることを確認
+			const unlabeledAfterAssign = await apiClient.getUnlabeledArticles();
+			expect(unlabeledAfterAssign.length).toBe(unlabeledArticles.length - 1);
+		});
+
+		test("複数の記事に一括でラベルを割り当てるワークフロー", async () => {
+			// 1. 未ラベル記事を取得
+			const unlabeledArticles = await apiClient.getUnlabeledArticles();
+			const articleIds = unlabeledArticles.map((a) => a.id);
+
+			// 2. 複数記事に一括でラベルを割り当て（ラベルは自動作成される）
+			const result = await apiClient.assignLabelsToMultipleArticles(
+				articleIds,
+				"一括ラベル",
+				"一括で割り当てたラベル",
+			);
+
+			expect(result.successful).toBe(articleIds.length);
+			expect(result.skipped).toBe(0);
+			expect(result.errors).toEqual([]);
+			expect(result.label.name).toBe("一括ラベル");
+
+			// 3. すべての記事がラベル付けされたことを確認
+			const unlabeledAfter = await apiClient.getUnlabeledArticles();
+			expect(unlabeledAfter).toEqual([]);
+		});
+
+		test("既存のラベルに記事を追加するワークフロー", async () => {
+			// 1. ラベルを作成
+			const label = await apiClient.createLabel("既存ラベル");
+
+			// 2. 最初の記事にラベルを割り当て
+			const articles = await apiClient.getUnlabeledArticles();
+			await apiClient.assignLabelToArticle(articles[0].id, "既存ラベル");
+
+			// 3. 別の記事に同じラベルを割り当て
+			await apiClient.assignLabelToArticle(articles[1].id, "既存ラベル");
+
+			// 4. ラベルの数が増えていないことを確認（既存のラベルを使用）
+			const labels = await apiClient.getLabels();
+			expect(labels).toHaveLength(1);
+			expect(labels[0].name).toBe("既存ラベル");
+		});
+	});
+
+	describe("エラーケースの統合テスト", () => {
+		test("重複するラベル名での作成がエラーになること", async () => {
+			// 1. 最初のラベルを作成
+			await apiClient.createLabel("重複ラベル", "最初の説明");
+
+			// 2. 同じ名前で再度作成を試みる
+			await expect(
+				apiClient.createLabel("重複ラベル", "別の説明"),
+			).rejects.toThrow("Label already exists");
+
+			// 3. ラベルは1つだけ存在することを確認
+			const labels = await apiClient.getLabels();
+			expect(labels).toHaveLength(1);
+		});
+
+		test("存在しない記事へのラベル割り当てがエラーになること", async () => {
+			await expect(
+				apiClient.assignLabelToArticle(999, "テストラベル"),
+			).rejects.toThrow("Failed to assign label");
+		});
+
+		test("使用中のラベルの削除がエラーになること", async () => {
+			// 1. ラベルを作成
+			const label = await apiClient.createLabel("使用中ラベル");
+
+			// 2. 記事にラベルを割り当て
+			const articles = await apiClient.getUnlabeledArticles();
+			await apiClient.assignLabelToArticle(articles[0].id, "使用中ラベル");
+
+			// 3. ラベルの削除を試みる（失敗するはず）
+			await expect(apiClient.deleteLabel(label.id)).rejects.toThrow(
+				"Cannot delete label: still in use",
+			);
+		});
+
+		test("複数記事への一括割り当てで一部が失敗するケース", async () => {
+			const validIds = [1, 2];
+			const invalidIds = [999, 1000];
+			const mixedIds = [...validIds, ...invalidIds];
+
+			const result = await apiClient.assignLabelsToMultipleArticles(
+				mixedIds,
+				"混在ラベル",
+			);
+
+			expect(result.successful).toBe(2);
+			expect(result.skipped).toBe(0);
+			expect(result.errors).toHaveLength(2);
+			expect(result.errors[0].articleId).toBe(999);
+			expect(result.errors[0].error).toBe("Article not found");
+		});
+	});
+
+	describe("ラベルの更新と削除のフロー", () => {
+		test("ラベルの説明を更新するワークフロー", async () => {
+			// 1. ラベルを作成
+			const label = await apiClient.createLabel("更新テスト", "初期説明");
+
+			// 2. ラベルの説明を更新
+			const updated = await apiClient.updateLabelDescription(
+				label.id,
+				"更新された説明",
+			);
+			expect(updated.description).toBe("更新された説明");
+
+			// 3. 更新が永続化されていることを確認
+			const fetched = await apiClient.getLabelById(label.id);
+			expect(fetched.description).toBe("更新された説明");
+
+			// 4. 説明をnullに設定
+			const nullified = await apiClient.updateLabelDescription(label.id, null);
+			expect(nullified.description).toBeNull();
+		});
+
+		test("未使用ラベルを削除するワークフロー", async () => {
+			// 1. 複数のラベルを作成
+			const label1 = await apiClient.createLabel("削除対象1");
+			const label2 = await apiClient.createLabel("削除対象2");
+
+			// 2. ラベルが存在することを確認
+			const labelsBeforeDelete = await apiClient.getLabels();
+			expect(labelsBeforeDelete).toHaveLength(2);
+
+			// 3. 一つ目のラベルを削除
+			await apiClient.deleteLabel(label1.id);
+
+			// 4. ラベルが削除されたことを確認
+			const labelsAfterDelete = await apiClient.getLabels();
+			expect(labelsAfterDelete).toHaveLength(1);
+			expect(labelsAfterDelete[0].id).toBe(label2.id);
+
+			// 5. 削除されたラベルの取得がエラーになることを確認
+			await expect(apiClient.getLabelById(label1.id)).rejects.toThrow(
+				"Failed to fetch label",
+			);
+		});
+	});
+
+	describe("重複処理の防止", () => {
+		test("同じ記事に同じラベルを再度割り当てた場合スキップされること", async () => {
+			const articles = await apiClient.getUnlabeledArticles();
+			const articleId = articles[0].id;
+
+			// 1. 最初の割り当て
+			await apiClient.assignLabelToArticle(articleId, "重複テスト");
+
+			// 2. 同じ記事に同じラベルを一括割り当て
+			const result = await apiClient.assignLabelsToMultipleArticles(
+				[articleId],
+				"重複テスト",
+			);
+
+			expect(result.successful).toBe(0);
+			expect(result.skipped).toBe(1);
+			expect(result.errors).toEqual([]);
+		});
+
+		test("複数回の一括割り当てで適切にスキップされること", async () => {
+			const articles = await apiClient.getUnlabeledArticles();
+			const articleIds = articles.map((a) => a.id);
+
+			// 1. 最初の一括割り当て
+			const firstResult = await apiClient.assignLabelsToMultipleArticles(
+				articleIds,
+				"一括テスト",
+			);
+			expect(firstResult.successful).toBe(articleIds.length);
+
+			// 2. 同じ記事に再度一括割り当て
+			const secondResult = await apiClient.assignLabelsToMultipleArticles(
+				articleIds,
+				"一括テスト",
+			);
+			expect(secondResult.successful).toBe(0);
+			expect(secondResult.skipped).toBe(articleIds.length);
+		});
+	});
+});
+
+describe("Concurrent Operations", () => {
+	let fetchMock: MockInstance;
+
+	beforeEach(() => {
+		process.env.API_BASE_URL = "http://localhost:3000";
+		fetchMock = vi.spyOn(global, "fetch");
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	test("複数の並行リクエストが正しく処理されること", async () => {
+		let callCount = 0;
+		fetchMock.mockImplementation(async () => {
+			callCount++;
+			// 各リクエストに異なる遅延を設定
+			await new Promise((resolve) => setTimeout(resolve, Math.random() * 10));
+
+			return {
+				ok: true,
+				json: async () => ({
+					success: true,
+					labels: [{ id: callCount, name: `Label${callCount}` }],
+				}),
+			} as Response;
+		});
+
+		// 並行して複数のリクエストを送信
+		const promises = [
+			apiClient.getLabels(),
+			apiClient.getLabels(),
+			apiClient.getLabels(),
+		];
+
+		const results = await Promise.all(promises);
+
+		// すべてのリクエストが処理されたことを確認
+		expect(callCount).toBe(3);
+		expect(results).toHaveLength(3);
+	});
+});

--- a/mcp/src/test/apiClient.labels.test.ts
+++ b/mcp/src/test/apiClient.labels.test.ts
@@ -1,0 +1,772 @@
+/**
+ * MCPサーバーのラベル関連機能の包括的なテスト
+ */
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import type { MockInstance } from "vitest";
+import * as apiClient from "../lib/apiClient.js";
+
+describe("Label API Functions", () => {
+	let fetchMock: MockInstance;
+	const originalEnv = process.env.API_BASE_URL;
+
+	beforeEach(() => {
+		// 環境変数をモック
+		process.env.API_BASE_URL = "http://localhost:3000";
+		// fetchをモック化
+		fetchMock = vi.spyOn(global, "fetch");
+	});
+
+	afterEach(() => {
+		// 環境変数を復元
+		if (originalEnv) {
+			process.env.API_BASE_URL = originalEnv;
+		} else {
+			delete process.env.API_BASE_URL;
+		}
+		// モックをリセット
+		vi.restoreAllMocks();
+	});
+
+	describe("getLabels", () => {
+		test("正常にラベル一覧を取得できること", async () => {
+			const mockLabels = [
+				{
+					id: 1,
+					name: "技術記事",
+					description: "技術関連の記事",
+					createdAt: "2024-01-01T00:00:00Z",
+					updatedAt: "2024-01-01T00:00:00Z",
+				},
+				{
+					id: 2,
+					name: "ニュース",
+					description: null,
+					createdAt: "2024-01-02T00:00:00Z",
+					updatedAt: "2024-01-02T00:00:00Z",
+				},
+			];
+
+			fetchMock.mockResolvedValueOnce({
+				ok: true,
+				json: async () => ({
+					success: true,
+					labels: mockLabels,
+				}),
+			} as Response);
+
+			const result = await apiClient.getLabels();
+
+			expect(fetchMock).toHaveBeenCalledWith("http://localhost:3000/api/labels");
+			expect(result).toEqual(mockLabels);
+		});
+
+		test("APIエラー時に適切なエラーをスローすること", async () => {
+			fetchMock.mockResolvedValueOnce({
+				ok: false,
+				statusText: "Internal Server Error",
+			} as Response);
+
+			await expect(apiClient.getLabels()).rejects.toThrow(
+				"Failed to fetch labels: Internal Server Error",
+			);
+		});
+
+		test("不正なレスポンス形式でエラーをスローすること", async () => {
+			fetchMock.mockResolvedValueOnce({
+				ok: true,
+				json: async () => ({
+					// success: trueが欠けている
+					labels: [],
+				}),
+			} as Response);
+
+			await expect(apiClient.getLabels()).rejects.toThrow(
+				"Invalid API response for labels:",
+			);
+		});
+
+		test("空のラベル配列を正常に処理できること", async () => {
+			fetchMock.mockResolvedValueOnce({
+				ok: true,
+				json: async () => ({
+					success: true,
+					labels: [],
+				}),
+			} as Response);
+
+			const result = await apiClient.getLabels();
+			expect(result).toEqual([]);
+		});
+	});
+
+	describe("getUnlabeledArticles", () => {
+		test("正常に未ラベル記事を取得できること", async () => {
+			const mockArticles = [
+				{
+					id: 1,
+					title: "Test Article 1",
+					url: "https://example.com/1",
+					isRead: false,
+					createdAt: "2024-01-01T00:00:00Z",
+					updatedAt: "2024-01-01T00:00:00Z",
+				},
+				{
+					id: 2,
+					title: "Test Article 2",
+					url: "https://example.com/2",
+					isRead: true,
+					createdAt: "2024-01-02T00:00:00Z",
+					updatedAt: "2024-01-02T00:00:00Z",
+				},
+			];
+
+			fetchMock.mockResolvedValueOnce({
+				ok: true,
+				json: async () => ({
+					success: true,
+					bookmarks: mockArticles,
+				}),
+			} as Response);
+
+			const result = await apiClient.getUnlabeledArticles();
+
+			expect(fetchMock).toHaveBeenCalledWith(
+				"http://localhost:3000/api/bookmarks/unlabeled",
+			);
+			expect(result).toEqual(
+				mockArticles.map((article) => ({
+					...article,
+					label: null,
+					isFavorite: false,
+				})),
+			);
+		});
+
+		test("APIエラー時に適切なエラーをスローすること", async () => {
+			fetchMock.mockResolvedValueOnce({
+				ok: false,
+				statusText: "Not Found",
+			} as Response);
+
+			await expect(apiClient.getUnlabeledArticles()).rejects.toThrow(
+				"Failed to fetch unlabeled articles: Not Found",
+			);
+		});
+
+		test("不正なレスポンス形式でエラーをスローすること", async () => {
+			fetchMock.mockResolvedValueOnce({
+				ok: true,
+				json: async () => ({
+					success: true,
+					// bookmarksではなくarticlesというキー
+					articles: [],
+				}),
+			} as Response);
+
+			await expect(apiClient.getUnlabeledArticles()).rejects.toThrow(
+				"Invalid API response for unlabeled articles",
+			);
+		});
+	});
+
+	describe("assignLabel", () => {
+		test("正常にラベルを記事に割り当てできること", async () => {
+			fetchMock.mockResolvedValueOnce({
+				ok: true,
+				json: async () => ({ success: true }),
+			} as Response);
+
+			await apiClient.assignLabelToArticle(1, "技術記事", "技術関連の記事");
+
+			expect(fetchMock).toHaveBeenCalledWith(
+				"http://localhost:3000/api/bookmarks/1/label",
+				{
+					method: "PUT",
+					headers: {
+						"Content-Type": "application/json",
+					},
+					body: JSON.stringify({
+						labelName: "技術記事",
+						description: "技術関連の記事",
+					}),
+				},
+			);
+		});
+
+		test("説明なしでラベルを割り当てできること", async () => {
+			fetchMock.mockResolvedValueOnce({
+				ok: true,
+				json: async () => ({ success: true }),
+			} as Response);
+
+			await apiClient.assignLabelToArticle(1, "技術記事");
+
+			expect(fetchMock).toHaveBeenCalledWith(
+				"http://localhost:3000/api/bookmarks/1/label",
+				{
+					method: "PUT",
+					headers: {
+						"Content-Type": "application/json",
+					},
+					body: JSON.stringify({
+						labelName: "技術記事",
+						description: undefined,
+					}),
+				},
+			);
+		});
+
+		test("APIエラー時に適切なエラーをスローすること", async () => {
+			fetchMock.mockResolvedValueOnce({
+				ok: false,
+				statusText: "Bad Request",
+			} as Response);
+
+			await expect(
+				apiClient.assignLabelToArticle(1, "技術記事"),
+			).rejects.toThrow(
+				'Failed to assign label "技術記事" to article 1: Bad Request',
+			);
+		});
+	});
+
+	describe("assignLabelsToMultipleArticles", () => {
+		test("正常に複数記事にラベルを割り当てできること", async () => {
+			const mockResponse = {
+				success: true,
+				successful: 3,
+				skipped: 1,
+				errors: [],
+				label: {
+					id: 1,
+					name: "技術記事",
+					description: "技術関連の記事",
+					createdAt: "2024-01-01T00:00:00Z",
+					updatedAt: "2024-01-01T00:00:00Z",
+				},
+			};
+
+			fetchMock.mockResolvedValueOnce({
+				ok: true,
+				json: async () => mockResponse,
+			} as Response);
+
+			const result = await apiClient.assignLabelsToMultipleArticles(
+				[1, 2, 3, 4],
+				"技術記事",
+				"技術関連の記事",
+			);
+
+			expect(fetchMock).toHaveBeenCalledWith(
+				"http://localhost:3000/api/bookmarks/batch-label",
+				{
+					method: "PUT",
+					headers: {
+						"Content-Type": "application/json",
+					},
+					body: JSON.stringify({
+						articleIds: [1, 2, 3, 4],
+						labelName: "技術記事",
+						description: "技術関連の記事",
+					}),
+				},
+			);
+
+			expect(result).toEqual({
+				successful: 3,
+				skipped: 1,
+				errors: [],
+				label: mockResponse.label,
+			});
+		});
+
+		test("エラーが含まれるレスポンスを正しく処理できること", async () => {
+			const mockResponse = {
+				success: true,
+				successful: 2,
+				skipped: 0,
+				errors: [
+					{ articleId: 3, error: "Article not found" },
+					{ articleId: 4, error: "Database error" },
+				],
+				label: {
+					id: 1,
+					name: "技術記事",
+					description: null,
+					createdAt: "2024-01-01T00:00:00Z",
+					updatedAt: "2024-01-01T00:00:00Z",
+				},
+			};
+
+			fetchMock.mockResolvedValueOnce({
+				ok: true,
+				json: async () => mockResponse,
+			} as Response);
+
+			const result = await apiClient.assignLabelsToMultipleArticles(
+				[1, 2, 3, 4],
+				"技術記事",
+			);
+
+			expect(result.errors).toHaveLength(2);
+			expect(result.errors[0]).toEqual({
+				articleId: 3,
+				error: "Article not found",
+			});
+		});
+
+		test("空の記事ID配列でも正常に処理できること", async () => {
+			const mockResponse = {
+				success: true,
+				successful: 0,
+				skipped: 0,
+				errors: [],
+				label: {
+					id: 1,
+					name: "技術記事",
+					description: null,
+					createdAt: "2024-01-01T00:00:00Z",
+					updatedAt: "2024-01-01T00:00:00Z",
+				},
+			};
+
+			fetchMock.mockResolvedValueOnce({
+				ok: true,
+				json: async () => mockResponse,
+			} as Response);
+
+			const result = await apiClient.assignLabelsToMultipleArticles(
+				[],
+				"技術記事",
+			);
+
+			expect(result.successful).toBe(0);
+			expect(result.skipped).toBe(0);
+			expect(result.errors).toEqual([]);
+		});
+
+		test("APIエラー時に適切なエラーをスローすること", async () => {
+			fetchMock.mockResolvedValueOnce({
+				ok: false,
+				statusText: "Bad Request",
+				json: async () => ({
+					message: "Invalid label name",
+				}),
+			} as Response);
+
+			await expect(
+				apiClient.assignLabelsToMultipleArticles([1, 2], ""),
+			).rejects.toThrow("Invalid label name: Bad Request");
+		});
+
+		test("JSONパースエラー時に適切なエラーをスローすること", async () => {
+			fetchMock.mockResolvedValueOnce({
+				ok: true,
+				json: async () => {
+					throw new Error("Invalid JSON");
+				},
+			} as Response);
+
+			await expect(
+				apiClient.assignLabelsToMultipleArticles([1], "test"),
+			).rejects.toThrow(
+				"Failed to parse response for batch label assignment: Invalid JSON",
+			);
+		});
+
+		test("不正なレスポンス形式でエラーをスローすること", async () => {
+			fetchMock.mockResolvedValueOnce({
+				ok: true,
+				json: async () => ({
+					// success: trueが欠けている
+					successful: 1,
+					skipped: 0,
+					errors: [],
+				}),
+			} as Response);
+
+			await expect(
+				apiClient.assignLabelsToMultipleArticles([1], "test"),
+			).rejects.toThrow("Invalid API response for batch label assignment:");
+		});
+
+		test("null/undefined レスポンスを適切に処理すること", async () => {
+			// nullレスポンスのテスト
+			fetchMock.mockResolvedValueOnce({
+				ok: true,
+				json: async () => null,
+			} as Response);
+
+			await expect(
+				apiClient.assignLabelsToMultipleArticles([1], "test"),
+			).rejects.toThrow("Invalid API response for batch label assignment:");
+
+			// undefinedレスポンスのテスト
+			fetchMock.mockResolvedValueOnce({
+				ok: true,
+				json: async () => undefined,
+			} as Response);
+
+			await expect(
+				apiClient.assignLabelsToMultipleArticles([1], "test"),
+			).rejects.toThrow("Invalid API response for batch label assignment:");
+		});
+	});
+
+	describe("createLabel", () => {
+		test("正常に新しいラベルを作成できること", async () => {
+			const mockLabel = {
+				id: 1,
+				name: "新規ラベル",
+				description: "新しいラベルの説明",
+				createdAt: "2024-01-01T00:00:00Z",
+				updatedAt: "2024-01-01T00:00:00Z",
+			};
+
+			fetchMock.mockResolvedValueOnce({
+				ok: true,
+				headers: new Headers({ "content-type": "application/json" }),
+				json: async () => ({
+					success: true,
+					label: mockLabel,
+				}),
+			} as Response);
+
+			const result = await apiClient.createLabel("新規ラベル", "新しいラベルの説明");
+
+			expect(fetchMock).toHaveBeenCalledWith("http://localhost:3000/api/labels", {
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+				},
+				body: JSON.stringify({
+					name: "新規ラベル",
+					description: "新しいラベルの説明",
+				}),
+			});
+
+			expect(result).toEqual(mockLabel);
+		});
+
+		test("説明なしでラベルを作成できること", async () => {
+			const mockLabel = {
+				id: 1,
+				name: "新規ラベル",
+				description: null,
+				createdAt: "2024-01-01T00:00:00Z",
+				updatedAt: "2024-01-01T00:00:00Z",
+			};
+
+			fetchMock.mockResolvedValueOnce({
+				ok: true,
+				headers: new Headers({ "content-type": "application/json" }),
+				json: async () => ({
+					success: true,
+					label: mockLabel,
+				}),
+			} as Response);
+
+			const result = await apiClient.createLabel("新規ラベル");
+
+			expect(result.description).toBeNull();
+		});
+
+		test("重複するラベル名でエラーをスローすること", async () => {
+			fetchMock.mockResolvedValueOnce({
+				ok: false,
+				status: 409,
+				statusText: "Conflict",
+				headers: new Headers({ "content-type": "application/json" }),
+				json: async () => ({
+					message: "Label already exists",
+				}),
+			} as Response);
+
+			await expect(apiClient.createLabel("既存ラベル")).rejects.toThrow(
+				"Label already exists: Conflict (Status: 409)",
+			);
+		});
+
+		test("JSONパースエラー時に適切なエラーをスローすること", async () => {
+			fetchMock.mockResolvedValueOnce({
+				ok: false,
+				status: 400,
+				statusText: "Bad Request",
+				json: async () => {
+					throw new Error("Invalid JSON");
+				},
+			} as Response);
+
+			await expect(apiClient.createLabel("test")).rejects.toThrow(
+				'Failed to create label "test". Status: 400 Bad Request',
+			);
+		});
+	});
+
+	describe("getLabelById", () => {
+		test("正常に特定のラベルを取得できること", async () => {
+			const mockLabel = {
+				id: 1,
+				name: "技術記事",
+				description: "技術関連の記事",
+				createdAt: "2024-01-01T00:00:00Z",
+				updatedAt: "2024-01-01T00:00:00Z",
+			};
+
+			fetchMock.mockResolvedValueOnce({
+				ok: true,
+				json: async () => ({
+					success: true,
+					label: mockLabel,
+				}),
+			} as Response);
+
+			const result = await apiClient.getLabelById(1);
+
+			expect(fetchMock).toHaveBeenCalledWith(
+				"http://localhost:3000/api/labels/1",
+			);
+			expect(result).toEqual(mockLabel);
+		});
+
+		test("存在しないIDでエラーをスローすること", async () => {
+			fetchMock.mockResolvedValueOnce({
+				ok: false,
+				statusText: "Not Found",
+			} as Response);
+
+			await expect(apiClient.getLabelById(999)).rejects.toThrow(
+				"Failed to fetch label with ID 999: Not Found",
+			);
+		});
+
+		test("JSONパースエラー時に適切なエラーをスローすること", async () => {
+			fetchMock.mockResolvedValueOnce({
+				ok: true,
+				json: async () => {
+					throw new Error("Invalid JSON");
+				},
+			} as Response);
+
+			await expect(apiClient.getLabelById(1)).rejects.toThrow(
+				"Failed to parse response when fetching label 1: Invalid JSON",
+			);
+		});
+	});
+
+	describe("updateLabelDescription", () => {
+		test("正常にラベルの説明を更新できること", async () => {
+			const mockLabel = {
+				id: 1,
+				name: "技術記事",
+				description: "更新された説明",
+				createdAt: "2024-01-01T00:00:00Z",
+				updatedAt: "2024-01-02T00:00:00Z",
+			};
+
+			fetchMock.mockResolvedValueOnce({
+				ok: true,
+				json: async () => ({
+					success: true,
+					label: mockLabel,
+				}),
+			} as Response);
+
+			const result = await apiClient.updateLabelDescription(1, "更新された説明");
+
+			expect(fetchMock).toHaveBeenCalledWith(
+				"http://localhost:3000/api/labels/1",
+				{
+					method: "PATCH",
+					headers: {
+						"Content-Type": "application/json",
+					},
+					body: JSON.stringify({ description: "更新された説明" }),
+				},
+			);
+
+			expect(result).toEqual(mockLabel);
+		});
+
+		test("説明をnullに設定できること", async () => {
+			const mockLabel = {
+				id: 1,
+				name: "技術記事",
+				description: null,
+				createdAt: "2024-01-01T00:00:00Z",
+				updatedAt: "2024-01-02T00:00:00Z",
+			};
+
+			fetchMock.mockResolvedValueOnce({
+				ok: true,
+				json: async () => ({
+					success: true,
+					label: mockLabel,
+				}),
+			} as Response);
+
+			const result = await apiClient.updateLabelDescription(1, null);
+
+			expect(result.description).toBeNull();
+		});
+
+		test("APIエラー時に適切なエラーをスローすること", async () => {
+			fetchMock.mockResolvedValueOnce({
+				ok: false,
+				statusText: "Not Found",
+			} as Response);
+
+			await expect(
+				apiClient.updateLabelDescription(999, "新しい説明"),
+			).rejects.toThrow(
+				"Failed to update description for label 999: Not Found",
+			);
+		});
+	});
+
+	describe("deleteLabel", () => {
+		test("正常にラベルを削除できること", async () => {
+			fetchMock.mockResolvedValueOnce({
+				ok: true,
+				json: async () => ({
+					success: true,
+					message: "Label deleted successfully",
+				}),
+			} as Response);
+
+			await expect(apiClient.deleteLabel(1)).resolves.toBeUndefined();
+
+			expect(fetchMock).toHaveBeenCalledWith(
+				"http://localhost:3000/api/labels/1",
+				{
+					method: "DELETE",
+				},
+			);
+		});
+
+		test("存在しないラベルの削除でエラーをスローすること", async () => {
+			fetchMock.mockResolvedValueOnce({
+				ok: false,
+				status: 404,
+				statusText: "Not Found",
+				json: async () => ({
+					message: "Label not found",
+				}),
+			} as Response);
+
+			await expect(apiClient.deleteLabel(999)).rejects.toThrow(
+				"Label not found: Not Found (Status: 404)",
+			);
+		});
+
+		test("使用中のラベルの削除でエラーをスローすること", async () => {
+			fetchMock.mockResolvedValueOnce({
+				ok: false,
+				status: 409,
+				statusText: "Conflict",
+				json: async () => ({
+					message: "Cannot delete label: still in use",
+				}),
+			} as Response);
+
+			await expect(apiClient.deleteLabel(1)).rejects.toThrow(
+				"Cannot delete label: still in use: Conflict (Status: 409)",
+			);
+		});
+	});
+
+	describe("Environment Variable Handling", () => {
+		test("API_BASE_URLが設定されていない場合エラーをスローすること", async () => {
+			delete process.env.API_BASE_URL;
+
+			await expect(apiClient.getLabels()).rejects.toThrow(
+				"API_BASE_URL environment variable is not set",
+			);
+		});
+
+		test("API_BASE_URLが正しく使用されること", async () => {
+			process.env.API_BASE_URL = "https://api.example.com";
+
+			fetchMock.mockResolvedValueOnce({
+				ok: true,
+				json: async () => ({
+					success: true,
+					labels: [],
+				}),
+			} as Response);
+
+			await apiClient.getLabels();
+
+			expect(fetchMock).toHaveBeenCalledWith("https://api.example.com/api/labels");
+		});
+	});
+
+	describe("Input Validation", () => {
+		test("記事IDに負の値を指定した場合でもAPIリクエストは送信されること", async () => {
+			fetchMock.mockResolvedValueOnce({
+				ok: false,
+				statusText: "Bad Request",
+			} as Response);
+
+			await expect(apiClient.assignLabelToArticle(-1, "test")).rejects.toThrow(
+				'Failed to assign label "test" to article -1: Bad Request',
+			);
+
+			expect(fetchMock).toHaveBeenCalled();
+		});
+
+		test("空のラベル名でもAPIリクエストは送信されること", async () => {
+			fetchMock.mockResolvedValueOnce({
+				ok: false,
+				statusText: "Bad Request",
+			} as Response);
+
+			await expect(apiClient.assignLabelToArticle(1, "")).rejects.toThrow(
+				'Failed to assign label "" to article 1: Bad Request',
+			);
+
+			expect(fetchMock).toHaveBeenCalled();
+		});
+
+		test("特殊文字を含むラベル名が適切にエンコードされること", async () => {
+			fetchMock.mockResolvedValueOnce({
+				ok: true,
+				json: async () => ({ success: true }),
+			} as Response);
+
+			const specialLabelName = "テスト/ラベル#1 & 特殊文字";
+			await apiClient.assignLabelToArticle(1, specialLabelName, "説明");
+
+			const callArgs = fetchMock.mock.calls[0];
+			const body = JSON.parse(callArgs[1].body as string);
+			expect(body.labelName).toBe(specialLabelName);
+		});
+	});
+});
+
+describe("Error Recovery and Retry Logic", () => {
+	let fetchMock: MockInstance;
+
+	beforeEach(() => {
+		process.env.API_BASE_URL = "http://localhost:3000";
+		fetchMock = vi.spyOn(global, "fetch");
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	test("ネットワークエラー時に適切なエラーメッセージを返すこと", async () => {
+		fetchMock.mockRejectedValueOnce(new Error("Network error"));
+
+		await expect(apiClient.getLabels()).rejects.toThrow("Network error");
+	});
+
+	test("タイムアウトエラーを適切に処理すること", async () => {
+		fetchMock.mockRejectedValueOnce(new Error("Request timeout"));
+
+		await expect(apiClient.getUnlabeledArticles()).rejects.toThrow(
+			"Request timeout",
+		);
+	});
+});

--- a/mcp/src/test/apiClient.labels.test.ts
+++ b/mcp/src/test/apiClient.labels.test.ts
@@ -365,7 +365,7 @@ describe("Label API Functions", () => {
 				json: async () => {
 					throw new Error("Invalid JSON");
 				},
-			} as Response);
+			} as unknown as Response);
 
 			await expect(
 				apiClient.assignLabelsToMultipleArticles([1], "test"),
@@ -495,7 +495,7 @@ describe("Label API Functions", () => {
 				json: async () => {
 					throw new Error("Invalid JSON");
 				},
-			} as Response);
+			} as unknown as Response);
 
 			await expect(apiClient.createLabel("test")).rejects.toThrow(
 				'Failed to create label "test". Status: 400 Bad Request',
@@ -546,7 +546,7 @@ describe("Label API Functions", () => {
 				json: async () => {
 					throw new Error("Invalid JSON");
 				},
-			} as Response);
+			} as unknown as Response);
 
 			await expect(apiClient.getLabelById(1)).rejects.toThrow(
 				"Failed to parse response when fetching label 1: Invalid JSON",


### PR DESCRIPTION
## 概要
Claude Code Actionを使用した自動ラベル付け機能の動作確認を行い、エラーハンドリング・監視機能の改善とテストの追加を実施しました。

## 変更内容

### 🔧 ワークフローの改善 (.github/workflows/auto-labeling.yml)
- **リトライロジック**: 3段階のリトライ機構を実装（通常実行 → リトライ → 最終リトライ(最大10件)）
- **エラーハンドリング**: GitHub Actionsアノテーションによる詳細なステータス表示
- **自動通知**: 定期実行失敗時に自動でIssueを作成して通知
- **テストモード**: ドライランモードと処理記事数制限オプションの追加
- **実行統計**: ジョブサマリーで処理結果を可視化

### 🧪 MCPサーバーのテスト追加
- **包括的なテストカバレッジ**: 101個のテストを追加（すべて成功）
- **重点テスト項目**:
  - `assignLabelsToMultipleArticles`関数のnull/undefined処理
  - 入力検証（空配列、大量データ、無効なID）
  - APIエラーの適切な処理
  - エッジケースと境界値のテスト
- **テストカバレッジ**: 90.32%

## テスト結果
```
Test Files  5 passed (5)
     Tests  101 passed (101)
  Coverage  90.32% (statements)
```

## チェックリスト
- [x] ワークフローの改善実装
- [x] MCPサーバーのテスト追加
- [x] すべてのテストが成功することを確認
- [x] エラーハンドリングの動作確認

Fixes #794

🤖 Generated with [Claude Code](https://claude.ai/code)