### PR TITLE
🔧 pnpm専用環境を強制するためpreinstallスクリプトを追加 #797

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -1,6 +1,7 @@
 {
 	"name": "effective-yomimono-api",
 	"scripts": {
+		"preinstall": "npx only-allow pnpm",
 		"dev": "NODE_ENV=development wrangler dev --port 8787 --env development",
 		"deploy": "NODE_ENV=production wrangler deploy --minify",
 		"lint": "npx @biomejs/biome check",

--- a/extension/package.json
+++ b/extension/package.json
@@ -3,6 +3,7 @@
 	"version": "1.0.0",
 	"main": "background.js",
 	"scripts": {
+		"preinstall": "npx only-allow pnpm",
 		"test": "echo \"Error: no test specified\" && exit 1",
 		"lint": "npx @biomejs/biome check",
 		"format": "npx @biomejs/biome check --write",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,6 +3,7 @@
 	"version": "0.1.0",
 	"private": true,
 	"scripts": {
+		"preinstall": "npx only-allow pnpm",
 		"dev": "next dev",
 		"build": "next build",
 		"start": "next start",

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -16,6 +16,7 @@
 		"typescript": "^5.8.3"
 	},
 	"scripts": {
+		"preinstall": "npx only-allow pnpm",
 		"build": "tsc",
 		"lint": "biome check --write .",
 		"format": "biome format --write .",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "packageManager": "pnpm@9.14.4",
   "scripts": {
+    "preinstall": "npx only-allow pnpm",
     "lint": "pnpm run lint:api && pnpm run lint:frontend && pnpm run lint:extension && pnpm run lint:mcp",
     "lint:api": "cd api && pnpm run lint",
     "lint:frontend": "cd frontend && pnpm run lint",


### PR DESCRIPTION
## 概要
pnpm以外のパッケージマネージャー（npmやyarn）の使用を防止するため、各package.jsonにpreinstallスクリプトを追加しました。

## 変更内容
- ✅ ルートのpackage.jsonにpreinstallスクリプトを追加
- ✅ api/package.jsonにpreinstallスクリプトを追加  
- ✅ frontend/package.jsonにpreinstallスクリプトを追加
- ✅ extension/package.jsonにpreinstallスクリプトを追加
- ✅ mcp/package.jsonにpreinstallスクリプトを追加

## 動作確認
```bash
"preinstall": "npx only-allow pnpm"
```
このスクリプトにより、`npm install`や`yarn install`を実行しようとすると、エラーメッセージが表示されてpnpmの使用を強制します。

## 関連Issue
Closes #797

## チェックリスト
- [x] 各ディレクトリでテストを実行（既存の型エラーを除き問題なし）
- [x] lintチェックを実行
- [x] 型チェックを実行（既存のエラーは今回の変更とは無関係）

🤖 Generated with [Claude Code](https://claude.ai/code)