### PR TITLE
【本棚機能】フロントエンド実装 - 一覧画面

### DIFF
--- a/frontend/app/bookshelf/page.tsx
+++ b/frontend/app/bookshelf/page.tsx
@@ -1,0 +1,28 @@
+/**
+ * 本棚機能の一覧画面
+ * ユーザーが登録した本をステータス別に表示する
+ */
+
+import { BookshelfList } from "@/features/bookshelf/components/BookshelfList";
+
+export default function BookshelfPage() {
+	return (
+		<div className="container mx-auto p-4">
+			<h1 className="text-2xl font-bold mb-6 flex items-center gap-2">
+				<span>📚</span>
+				<span>私の本棚</span>
+			</h1>
+			<BookshelfList />
+		</div>
+	);
+}
+
+if (import.meta.vitest) {
+	const { test, expect, render, screen } = await import("@/test-utils");
+
+	test("本棚ページが正しく表示される", () => {
+		render(<BookshelfPage />);
+		expect(screen.getByText("私の本棚")).toBeInTheDocument();
+		expect(screen.getByText("📚")).toBeInTheDocument();
+	});
+}

--- a/frontend/features/bookshelf/components/AddBookButton.tsx
+++ b/frontend/features/bookshelf/components/AddBookButton.tsx
@@ -1,0 +1,66 @@
+/**
+ * 本追加ボタンコンポーネント
+ * 新しい本を本棚に追加するためのボタン
+ */
+
+"use client";
+
+import { useState } from "react";
+import { AddBookModal } from "./AddBookModal";
+
+export function AddBookButton() {
+	const [isModalOpen, setIsModalOpen] = useState(false);
+
+	return (
+		<>
+			<button
+				type="button"
+				onClick={() => setIsModalOpen(true)}
+				className="flex items-center gap-2 px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 transition-colors"
+			>
+				<svg
+					xmlns="http://www.w3.org/2000/svg"
+					className="h-5 w-5"
+					viewBox="0 0 20 20"
+					fill="currentColor"
+				>
+					<path
+						fillRule="evenodd"
+						d="M10 3a1 1 0 011 1v5h5a1 1 0 110 2h-5v5a1 1 0 11-2 0v-5H4a1 1 0 110-2h5V4a1 1 0 011-1z"
+						clipRule="evenodd"
+					/>
+				</svg>
+				<span>本を追加</span>
+			</button>
+
+			{isModalOpen && (
+				<AddBookModal
+					isOpen={isModalOpen}
+					onClose={() => setIsModalOpen(false)}
+				/>
+			)}
+		</>
+	);
+}
+
+if (import.meta.vitest) {
+	const { test, expect, render, screen } = await import("@/test-utils");
+
+	test("追加ボタンが表示される", () => {
+		render(<AddBookButton />);
+		expect(
+			screen.getByRole("button", { name: /本を追加/ }),
+		).toBeInTheDocument();
+	});
+
+	test("ボタンクリックでモーダルが開く", async () => {
+		const { user } = await import("@/test-utils");
+		render(<AddBookButton />);
+
+		const button = screen.getByRole("button", { name: /本を追加/ });
+		await user.click(button);
+
+		// モーダルが表示されることを確認（モーダルの実装後にテストを更新）
+		expect(screen.getByRole("dialog")).toBeInTheDocument();
+	});
+}

--- a/frontend/features/bookshelf/components/AddBookModal.tsx
+++ b/frontend/features/bookshelf/components/AddBookModal.tsx
@@ -1,0 +1,251 @@
+/**
+ * 本追加モーダルコンポーネント
+ * 新しい本の情報を入力して追加するモーダル
+ */
+
+"use client";
+
+import { useState } from "react";
+import { useBookshelf } from "../hooks/useBookshelf";
+import type { CreateBookRequest } from "../types";
+
+interface AddBookModalProps {
+	isOpen: boolean;
+	onClose: () => void;
+}
+
+export function AddBookModal({ isOpen, onClose }: AddBookModalProps) {
+	const { addBook } = useBookshelf();
+	const [formData, setFormData] = useState<CreateBookRequest>({
+		title: "",
+		author: "",
+		coverUrl: "",
+		status: "unread",
+		type: "book",
+		notes: "",
+	});
+	const [isSubmitting, setIsSubmitting] = useState(false);
+
+	if (!isOpen) return null;
+
+	const handleSubmit = async (e: React.FormEvent) => {
+		e.preventDefault();
+		setIsSubmitting(true);
+
+		try {
+			await addBook(formData);
+			onClose();
+		} catch (error) {
+			console.error("本の追加に失敗しました:", error);
+		} finally {
+			setIsSubmitting(false);
+		}
+	};
+
+	const handleChange = (
+		e: React.ChangeEvent<
+			HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement
+		>,
+	) => {
+		const { name, value } = e.target;
+		setFormData((prev) => ({ ...prev, [name]: value }));
+	};
+
+	return (
+		<div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-50">
+			<div
+				className="bg-white rounded-lg p-6 w-full max-w-md max-h-[90vh] overflow-y-auto"
+				role="dialog"
+				aria-labelledby="modal-title"
+			>
+				<h2 id="modal-title" className="text-xl font-bold mb-4">
+					本を追加
+				</h2>
+
+				<form onSubmit={handleSubmit} className="space-y-4">
+					<div>
+						<label htmlFor="title" className="block text-sm font-medium mb-1">
+							タイトル *
+						</label>
+						<input
+							type="text"
+							id="title"
+							name="title"
+							value={formData.title}
+							onChange={handleChange}
+							required
+							className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+						/>
+					</div>
+
+					<div>
+						<label htmlFor="author" className="block text-sm font-medium mb-1">
+							著者
+						</label>
+						<input
+							type="text"
+							id="author"
+							name="author"
+							value={formData.author}
+							onChange={handleChange}
+							className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+						/>
+					</div>
+
+					<div>
+						<label htmlFor="type" className="block text-sm font-medium mb-1">
+							タイプ *
+						</label>
+						<select
+							id="type"
+							name="type"
+							value={formData.type}
+							onChange={handleChange}
+							className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+						>
+							<option value="book">書籍</option>
+							<option value="pdf">PDF</option>
+							<option value="repository">リポジトリ</option>
+						</select>
+					</div>
+
+					<div>
+						<label htmlFor="status" className="block text-sm font-medium mb-1">
+							ステータス *
+						</label>
+						<select
+							id="status"
+							name="status"
+							value={formData.status}
+							onChange={handleChange}
+							className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+						>
+							<option value="unread">未読</option>
+							<option value="reading">読書中</option>
+							<option value="completed">読了</option>
+						</select>
+					</div>
+
+					<div>
+						<label
+							htmlFor="coverUrl"
+							className="block text-sm font-medium mb-1"
+						>
+							表紙画像URL
+						</label>
+						<input
+							type="url"
+							id="coverUrl"
+							name="coverUrl"
+							value={formData.coverUrl}
+							onChange={handleChange}
+							className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+						/>
+					</div>
+
+					<div>
+						<label htmlFor="notes" className="block text-sm font-medium mb-1">
+							メモ
+						</label>
+						<textarea
+							id="notes"
+							name="notes"
+							value={formData.notes}
+							onChange={handleChange}
+							rows={3}
+							className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+						/>
+					</div>
+
+					<div className="flex gap-3 justify-end pt-4">
+						<button
+							type="button"
+							onClick={onClose}
+							className="px-4 py-2 text-gray-600 hover:text-gray-800 transition-colors"
+						>
+							キャンセル
+						</button>
+						<button
+							type="submit"
+							disabled={isSubmitting}
+							className="px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+						>
+							{isSubmitting ? "追加中..." : "追加"}
+						</button>
+					</div>
+				</form>
+			</div>
+		</div>
+	);
+}
+
+if (import.meta.vitest) {
+	const { test, expect, render, screen, waitFor } = await import(
+		"@/test-utils"
+	);
+	const { vi } = await import("vitest");
+
+	// モックフック
+	vi.mock("../hooks/useBookshelf", () => ({
+		useBookshelf: vi.fn(() => ({
+			addBook: vi.fn(),
+		})),
+	}));
+
+	test("モーダルが表示される", () => {
+		render(<AddBookModal isOpen={true} onClose={vi.fn()} />);
+
+		expect(screen.getByRole("dialog")).toBeInTheDocument();
+		expect(screen.getByText("本を追加")).toBeInTheDocument();
+	});
+
+	test("必須フィールドが存在する", () => {
+		render(<AddBookModal isOpen={true} onClose={vi.fn()} />);
+
+		expect(screen.getByLabelText("タイトル *")).toBeInTheDocument();
+		expect(screen.getByLabelText("タイプ *")).toBeInTheDocument();
+		expect(screen.getByLabelText("ステータス *")).toBeInTheDocument();
+	});
+
+	test("フォーム送信が正しく動作する", async () => {
+		const { user } = await import("@/test-utils");
+		const { useBookshelf } = await import("../hooks/useBookshelf");
+		const mockAddBook = vi.fn();
+		const mockOnClose = vi.fn();
+
+		// @ts-expect-error - モック用の型アサーション
+		(useBookshelf as jest.Mock).mockReturnValue({
+			addBook: mockAddBook,
+		});
+
+		render(<AddBookModal isOpen={true} onClose={mockOnClose} />);
+
+		// フォーム入力
+		await user.type(screen.getByLabelText("タイトル *"), "テスト本");
+		await user.type(screen.getByLabelText("著者"), "テスト著者");
+
+		// 送信
+		await user.click(screen.getByRole("button", { name: "追加" }));
+
+		await waitFor(() => {
+			expect(mockAddBook).toHaveBeenCalledWith(
+				expect.objectContaining({
+					title: "テスト本",
+					author: "テスト著者",
+				}),
+			);
+			expect(mockOnClose).toHaveBeenCalled();
+		});
+	});
+
+	test("キャンセルボタンでモーダルが閉じる", async () => {
+		const { user } = await import("@/test-utils");
+		const mockOnClose = vi.fn();
+
+		render(<AddBookModal isOpen={true} onClose={mockOnClose} />);
+
+		await user.click(screen.getByRole("button", { name: "キャンセル" }));
+
+		expect(mockOnClose).toHaveBeenCalled();
+	});
+}

--- a/frontend/features/bookshelf/components/BookCard.tsx
+++ b/frontend/features/bookshelf/components/BookCard.tsx
@@ -1,0 +1,156 @@
+/**
+ * 本カードコンポーネント
+ * 個別の本の情報を表示するカード
+ */
+
+"use client";
+
+import Link from "next/link";
+import type { Book } from "../types";
+
+interface BookCardProps {
+	book: Book;
+}
+
+export function BookCard({ book }: BookCardProps) {
+	const statusLabels = {
+		unread: "未読",
+		reading: "読書中",
+		completed: "読了",
+	};
+
+	const statusColors = {
+		unread: "bg-gray-100 text-gray-700",
+		reading: "bg-blue-100 text-blue-700",
+		completed: "bg-green-100 text-green-700",
+	};
+
+	const typeIcons = {
+		book: "📚",
+		pdf: "📄",
+		repository: "🐙",
+	};
+
+	return (
+		<Link
+			href={`/bookshelf/${book.id}`}
+			className="block bg-white rounded-lg shadow-md hover:shadow-lg transition-shadow p-4 space-y-3"
+		>
+			{/* 表紙エリア */}
+			<div className="aspect-[3/4] bg-gray-100 rounded-md flex items-center justify-center text-4xl">
+				{book.coverUrl ? (
+					// biome-ignore lint/performance/noImgElement: パフォーマンス最適化はAPI統合後に実施
+					<img
+						src={book.coverUrl}
+						alt={book.title}
+						className="w-full h-full object-cover rounded-md"
+					/>
+				) : (
+					<span>{typeIcons[book.type]}</span>
+				)}
+			</div>
+
+			{/* 本の情報 */}
+			<div className="space-y-2">
+				<h3 className="font-semibold text-sm line-clamp-2" title={book.title}>
+					{book.title}
+				</h3>
+
+				{book.author && (
+					<p className="text-xs text-gray-600 line-clamp-1">{book.author}</p>
+				)}
+
+				{/* ステータスバッジ */}
+				<div className="flex items-center justify-between">
+					<span
+						className={`inline-block px-2 py-1 text-xs rounded-full ${
+							statusColors[book.status]
+						}`}
+					>
+						{statusLabels[book.status]}
+					</span>
+
+					{book.progress !== undefined && book.status === "reading" && (
+						<span className="text-xs text-gray-600">{book.progress}%</span>
+					)}
+				</div>
+			</div>
+		</Link>
+	);
+}
+
+if (import.meta.vitest) {
+	const { test, expect, render, screen } = await import("@/test-utils");
+
+	const mockBook: Book = {
+		id: "1",
+		title: "TypeScript実践ガイド",
+		author: "山田太郎",
+		status: "reading",
+		type: "book",
+		progress: 45,
+		createdAt: "2024-01-01",
+		updatedAt: "2024-01-01",
+	};
+
+	test("本カードが正しく表示される", () => {
+		render(<BookCard book={mockBook} />);
+
+		expect(screen.getByText("TypeScript実践ガイド")).toBeInTheDocument();
+		expect(screen.getByText("山田太郎")).toBeInTheDocument();
+		expect(screen.getByText("読書中")).toBeInTheDocument();
+		expect(screen.getByText("45%")).toBeInTheDocument();
+	});
+
+	test("カバー画像がない場合はアイコンが表示される", () => {
+		const bookWithoutCover = { ...mockBook, coverUrl: undefined };
+		render(<BookCard book={bookWithoutCover} />);
+
+		expect(screen.getByText("📚")).toBeInTheDocument();
+	});
+
+	test("PDFタイプの場合は正しいアイコンが表示される", () => {
+		const pdfBook = { ...mockBook, type: "pdf" as const, coverUrl: undefined };
+		render(<BookCard book={pdfBook} />);
+
+		expect(screen.getByText("📄")).toBeInTheDocument();
+	});
+
+	test("リポジトリタイプの場合は正しいアイコンが表示される", () => {
+		const repoBook = {
+			...mockBook,
+			type: "repository" as const,
+			coverUrl: undefined,
+		};
+		render(<BookCard book={repoBook} />);
+
+		expect(screen.getByText("🐙")).toBeInTheDocument();
+	});
+
+	test("詳細ページへのリンクが正しく設定される", () => {
+		render(<BookCard book={mockBook} />);
+
+		const link = screen.getByRole("link");
+		expect(link).toHaveAttribute("href", "/bookshelf/1");
+	});
+
+	test("進捗率は読書中の場合のみ表示される", () => {
+		const completedBook = {
+			...mockBook,
+			status: "completed" as const,
+			progress: 100,
+		};
+		const { rerender } = render(<BookCard book={completedBook} />);
+
+		expect(screen.queryByText("100%")).not.toBeInTheDocument();
+
+		const readingBook = {
+			...mockBook,
+			status: "reading" as const,
+			progress: 50,
+		};
+		rerender(<BookCard book={readingBook} />);
+
+		expect(screen.getByText("50%")).toBeInTheDocument();
+	});
+}

--- a/frontend/features/bookshelf/components/BookGrid.tsx
+++ b/frontend/features/bookshelf/components/BookGrid.tsx
@@ -1,0 +1,161 @@
+/**
+ * 本のグリッド表示コンポーネント
+ * ステータスに応じた本をグリッド形式で表示
+ */
+
+"use client";
+
+import { useEffect, useState } from "react";
+import { useBookshelf } from "../hooks/useBookshelf";
+import type { Book, BookStatus } from "../types";
+import { BookCard } from "./BookCard";
+
+interface BookGridProps {
+	status: BookStatus;
+}
+
+export function BookGrid({ status }: BookGridProps) {
+	const { books, loading, error, fetchBooks } = useBookshelf();
+	const [filteredBooks, setFilteredBooks] = useState<Book[]>([]);
+
+	useEffect(() => {
+		fetchBooks();
+	}, [fetchBooks]);
+
+	useEffect(() => {
+		setFilteredBooks(books.filter((book) => book.status === status));
+	}, [books, status]);
+
+	if (loading) {
+		return (
+			<div className="flex justify-center items-center h-64">
+				<div
+					data-testid="loading-spinner"
+					className="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-600"
+				/>
+			</div>
+		);
+	}
+
+	if (error) {
+		return (
+			<div className="text-center text-red-600 p-8">
+				<p>本の取得に失敗しました</p>
+				<button
+					type="button"
+					onClick={fetchBooks}
+					className="mt-4 px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700"
+				>
+					再試行
+				</button>
+			</div>
+		);
+	}
+
+	if (filteredBooks.length === 0) {
+		const statusLabels = {
+			unread: "未読",
+			reading: "読書中",
+			completed: "読了",
+		};
+		return (
+			<div className="text-center text-gray-500 p-12">
+				<p>{statusLabels[status]}の本はありません</p>
+			</div>
+		);
+	}
+
+	return (
+		<div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-6">
+			{filteredBooks.map((book) => (
+				<BookCard key={book.id} book={book} />
+			))}
+		</div>
+	);
+}
+
+if (import.meta.vitest) {
+	const { test, expect, render, screen, waitFor } = await import(
+		"@/test-utils"
+	);
+	const { vi } = await import("vitest");
+
+	// モックフック
+	vi.mock("../hooks/useBookshelf", () => ({
+		useBookshelf: vi.fn(() => ({
+			books: [
+				{
+					id: "1",
+					title: "テスト本1",
+					status: "unread",
+					type: "book",
+					createdAt: "2024-01-01",
+					updatedAt: "2024-01-01",
+				},
+				{
+					id: "2",
+					title: "テスト本2",
+					status: "reading",
+					type: "pdf",
+					createdAt: "2024-01-01",
+					updatedAt: "2024-01-01",
+				},
+			],
+			loading: false,
+			error: null,
+			fetchBooks: vi.fn(),
+		})),
+	}));
+
+	test("ローディング状態が表示される", async () => {
+		const { useBookshelf } = await import("../hooks/useBookshelf");
+		// @ts-expect-error - モック用の型アサーション
+		(useBookshelf as jest.Mock).mockReturnValue({
+			books: [],
+			loading: true,
+			error: null,
+			fetchBooks: vi.fn(),
+		});
+
+		render(<BookGrid status="unread" />);
+		expect(screen.getByTestId("loading-spinner")).toBeInTheDocument();
+	});
+
+	test("エラー状態が表示される", async () => {
+		const { useBookshelf } = await import("../hooks/useBookshelf");
+		// @ts-expect-error - モック用の型アサーション
+		(useBookshelf as jest.Mock).mockReturnValue({
+			books: [],
+			loading: false,
+			error: "エラー",
+			fetchBooks: vi.fn(),
+		});
+
+		render(<BookGrid status="unread" />);
+		expect(screen.getByText("本の取得に失敗しました")).toBeInTheDocument();
+		expect(screen.getByRole("button", { name: "再試行" })).toBeInTheDocument();
+	});
+
+	test("ステータスに応じた本が表示される", async () => {
+		render(<BookGrid status="unread" />);
+
+		await waitFor(() => {
+			expect(screen.getByText("テスト本1")).toBeInTheDocument();
+			expect(screen.queryByText("テスト本2")).not.toBeInTheDocument();
+		});
+	});
+
+	test("本がない場合のメッセージが表示される", async () => {
+		const { useBookshelf } = await import("../hooks/useBookshelf");
+		// @ts-expect-error - モック用の型アサーション
+		(useBookshelf as jest.Mock).mockReturnValue({
+			books: [],
+			loading: false,
+			error: null,
+			fetchBooks: vi.fn(),
+		});
+
+		render(<BookGrid status="completed" />);
+		expect(screen.getByText("読了の本はありません")).toBeInTheDocument();
+	});
+}

--- a/frontend/features/bookshelf/components/BookshelfList.tsx
+++ b/frontend/features/bookshelf/components/BookshelfList.tsx
@@ -1,0 +1,54 @@
+/**
+ * 本棚一覧コンポーネント
+ * ステータス別タブと本のグリッド表示を管理
+ */
+
+"use client";
+
+import { useState } from "react";
+import type { BookStatus } from "../types";
+import { AddBookButton } from "./AddBookButton";
+import { BookGrid } from "./BookGrid";
+import { StatusTabs } from "./StatusTabs";
+
+export function BookshelfList() {
+	const [activeTab, setActiveTab] = useState<BookStatus>("unread");
+
+	return (
+		<div className="space-y-6">
+			<div className="flex justify-between items-center">
+				<StatusTabs activeTab={activeTab} onTabChange={setActiveTab} />
+				<AddBookButton />
+			</div>
+			<BookGrid status={activeTab} />
+		</div>
+	);
+}
+
+if (import.meta.vitest) {
+	const { test, expect, render, screen } = await import("@/test-utils");
+
+	test("本棚一覧コンポーネントが正しく表示される", () => {
+		render(<BookshelfList />);
+
+		// タブが表示される
+		expect(screen.getByRole("tab", { name: "未読" })).toBeInTheDocument();
+		expect(screen.getByRole("tab", { name: "読書中" })).toBeInTheDocument();
+		expect(screen.getByRole("tab", { name: "読了" })).toBeInTheDocument();
+
+		// 追加ボタンが表示される
+		expect(
+			screen.getByRole("button", { name: /本を追加/ }),
+		).toBeInTheDocument();
+	});
+
+	test("タブ切り替えが正しく動作する", async () => {
+		const { user } = await import("@/test-utils");
+		render(<BookshelfList />);
+
+		const readingTab = screen.getByRole("tab", { name: "読書中" });
+		await user.click(readingTab);
+
+		expect(readingTab).toHaveAttribute("aria-selected", "true");
+	});
+}

--- a/frontend/features/bookshelf/components/StatusTabs.tsx
+++ b/frontend/features/bookshelf/components/StatusTabs.tsx
@@ -1,0 +1,77 @@
+/**
+ * ステータスタブコンポーネント
+ * 未読・読書中・読了の切り替えタブ
+ */
+
+"use client";
+
+import type { BookStatus } from "../types";
+
+interface StatusTabsProps {
+	activeTab: BookStatus;
+	onTabChange: (status: BookStatus) => void;
+}
+
+const tabs: { value: BookStatus; label: string }[] = [
+	{ value: "unread", label: "未読" },
+	{ value: "reading", label: "読書中" },
+	{ value: "completed", label: "読了" },
+];
+
+export function StatusTabs({ activeTab, onTabChange }: StatusTabsProps) {
+	return (
+		<div className="flex space-x-1 rounded-lg bg-gray-100 p-1" role="tablist">
+			{tabs.map((tab) => (
+				<button
+					key={tab.value}
+					type="button"
+					role="tab"
+					aria-selected={activeTab === tab.value}
+					onClick={() => onTabChange(tab.value)}
+					className={`
+						px-4 py-2 rounded-md font-medium text-sm transition-colors
+						${
+							activeTab === tab.value
+								? "bg-white text-blue-600 shadow-sm"
+								: "text-gray-600 hover:text-gray-900"
+						}
+					`}
+				>
+					{tab.label}
+				</button>
+			))}
+		</div>
+	);
+}
+
+if (import.meta.vitest) {
+	const { test, expect, render, screen } = await import("@/test-utils");
+	const { vi } = await import("vitest");
+
+	test("全てのタブが表示される", () => {
+		const mockOnTabChange = vi.fn();
+		render(<StatusTabs activeTab="unread" onTabChange={mockOnTabChange} />);
+
+		expect(screen.getByRole("tab", { name: "未読" })).toBeInTheDocument();
+		expect(screen.getByRole("tab", { name: "読書中" })).toBeInTheDocument();
+		expect(screen.getByRole("tab", { name: "読了" })).toBeInTheDocument();
+	});
+
+	test("アクティブタブが正しくハイライトされる", () => {
+		const mockOnTabChange = vi.fn();
+		render(<StatusTabs activeTab="reading" onTabChange={mockOnTabChange} />);
+
+		const readingTab = screen.getByRole("tab", { name: "読書中" });
+		expect(readingTab).toHaveAttribute("aria-selected", "true");
+		expect(readingTab).toHaveClass("bg-white", "text-blue-600");
+	});
+
+	test("タブクリックでコールバックが呼ばれる", async () => {
+		const { user } = await import("@/test-utils");
+		const mockOnTabChange = vi.fn();
+		render(<StatusTabs activeTab="unread" onTabChange={mockOnTabChange} />);
+
+		await user.click(screen.getByRole("tab", { name: "読了" }));
+		expect(mockOnTabChange).toHaveBeenCalledWith("completed");
+	});
+}

--- a/frontend/features/bookshelf/hooks/useBookshelf.ts
+++ b/frontend/features/bookshelf/hooks/useBookshelf.ts
@@ -1,0 +1,278 @@
+/**
+ * 本棚機能のカスタムフック
+ * APIとの通信とステート管理を行う
+ */
+
+"use client";
+
+import { useCallback, useState } from "react";
+import type { Book, CreateBookRequest } from "../types";
+
+export function useBookshelf() {
+	const [books, setBooks] = useState<Book[]>([]);
+	const [loading, setLoading] = useState(false);
+	const [error, setError] = useState<string | null>(null);
+
+	const fetchBooks = useCallback(async () => {
+		setLoading(true);
+		setError(null);
+
+		try {
+			// TODO: 実際のAPIエンドポイントに置き換える
+			const response = await fetch("/api/bookshelf");
+
+			if (!response.ok) {
+				throw new Error("本の取得に失敗しました");
+			}
+
+			const data = await response.json();
+			setBooks(data.books || []);
+		} catch (err) {
+			setError(err instanceof Error ? err.message : "エラーが発生しました");
+			// 開発用のモックデータ
+			setBooks([
+				{
+					id: "1",
+					title: "Clean Code",
+					author: "Robert C. Martin",
+					status: "reading",
+					type: "book",
+					progress: 65,
+					createdAt: "2024-01-01",
+					updatedAt: "2024-01-15",
+				},
+				{
+					id: "2",
+					title: "TypeScript Deep Dive",
+					status: "unread",
+					type: "pdf",
+					createdAt: "2024-01-05",
+					updatedAt: "2024-01-05",
+				},
+				{
+					id: "3",
+					title: "React Patterns",
+					status: "completed",
+					type: "repository",
+					createdAt: "2024-01-10",
+					updatedAt: "2024-01-20",
+				},
+			]);
+		} finally {
+			setLoading(false);
+		}
+	}, []);
+
+	const addBook = useCallback(async (bookData: CreateBookRequest) => {
+		setLoading(true);
+		setError(null);
+
+		try {
+			// TODO: 実際のAPIエンドポイントに置き換える
+			const response = await fetch("/api/bookshelf", {
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+				},
+				body: JSON.stringify(bookData),
+			});
+
+			if (!response.ok) {
+				throw new Error("本の追加に失敗しました");
+			}
+
+			const newBook = await response.json();
+			setBooks((prev) => [...prev, newBook]);
+
+			return newBook;
+		} catch (err) {
+			setError(err instanceof Error ? err.message : "エラーが発生しました");
+			// 開発用のモック処理
+			const newBook: Book = {
+				id: Date.now().toString(),
+				...bookData,
+				createdAt: new Date().toISOString(),
+				updatedAt: new Date().toISOString(),
+			};
+			setBooks((prev) => [...prev, newBook]);
+			return newBook;
+		} finally {
+			setLoading(false);
+		}
+	}, []);
+
+	const updateBookStatus = useCallback(
+		async (bookId: string, status: Book["status"], progress?: number) => {
+			setLoading(true);
+			setError(null);
+
+			try {
+				// TODO: 実際のAPIエンドポイントに置き換える
+				const response = await fetch(`/api/bookshelf/${bookId}`, {
+					method: "PATCH",
+					headers: {
+						"Content-Type": "application/json",
+					},
+					body: JSON.stringify({ status, progress }),
+				});
+
+				if (!response.ok) {
+					throw new Error("ステータスの更新に失敗しました");
+				}
+
+				const updatedBook = await response.json();
+				setBooks((prev) =>
+					prev.map((book) => (book.id === bookId ? updatedBook : book)),
+				);
+
+				return updatedBook;
+			} catch (err) {
+				setError(err instanceof Error ? err.message : "エラーが発生しました");
+				// 開発用のモック処理
+				setBooks((prev) =>
+					prev.map((book) =>
+						book.id === bookId
+							? {
+									...book,
+									status,
+									progress,
+									updatedAt: new Date().toISOString(),
+								}
+							: book,
+					),
+				);
+			} finally {
+				setLoading(false);
+			}
+		},
+		[],
+	);
+
+	const deleteBook = useCallback(async (bookId: string) => {
+		setLoading(true);
+		setError(null);
+
+		try {
+			// TODO: 実際のAPIエンドポイントに置き換える
+			const response = await fetch(`/api/bookshelf/${bookId}`, {
+				method: "DELETE",
+			});
+
+			if (!response.ok) {
+				throw new Error("本の削除に失敗しました");
+			}
+
+			setBooks((prev) => prev.filter((book) => book.id !== bookId));
+		} catch (err) {
+			setError(err instanceof Error ? err.message : "エラーが発生しました");
+			// 開発用のモック処理
+			setBooks((prev) => prev.filter((book) => book.id !== bookId));
+		} finally {
+			setLoading(false);
+		}
+	}, []);
+
+	return {
+		books,
+		loading,
+		error,
+		fetchBooks,
+		addBook,
+		updateBookStatus,
+		deleteBook,
+	};
+}
+
+if (import.meta.vitest) {
+	const { test, expect, renderHook, act, waitFor } = await import(
+		"@/test-utils"
+	);
+
+	test("初期状態が正しく設定される", () => {
+		const { result } = renderHook(() => useBookshelf());
+
+		expect(result.current.books).toEqual([]);
+		expect(result.current.loading).toBe(false);
+		expect(result.current.error).toBe(null);
+	});
+
+	test("fetchBooksが本のリストを取得する", async () => {
+		const { result } = renderHook(() => useBookshelf());
+
+		await act(async () => {
+			await result.current.fetchBooks();
+		});
+
+		await waitFor(() => {
+			expect(result.current.books.length).toBeGreaterThan(0);
+		});
+	});
+
+	test("addBookが新しい本を追加する", async () => {
+		const { result } = renderHook(() => useBookshelf());
+
+		const newBook = {
+			title: "新しい本",
+			status: "unread" as const,
+			type: "book" as const,
+		};
+
+		await act(async () => {
+			await result.current.addBook(newBook);
+		});
+
+		await waitFor(() => {
+			const addedBook = result.current.books.find(
+				(b) => b.title === "新しい本",
+			);
+			expect(addedBook).toBeDefined();
+			expect(addedBook?.status).toBe("unread");
+		});
+	});
+
+	test("updateBookStatusが本のステータスを更新する", async () => {
+		const { result } = renderHook(() => useBookshelf());
+
+		// まず本を取得
+		await act(async () => {
+			await result.current.fetchBooks();
+		});
+
+		const firstBook = result.current.books[0];
+
+		await act(async () => {
+			await result.current.updateBookStatus(firstBook.id, "completed", 100);
+		});
+
+		await waitFor(() => {
+			const updatedBook = result.current.books.find(
+				(b) => b.id === firstBook.id,
+			);
+			expect(updatedBook?.status).toBe("completed");
+			expect(updatedBook?.progress).toBe(100);
+		});
+	});
+
+	test("deleteBookが本を削除する", async () => {
+		const { result } = renderHook(() => useBookshelf());
+
+		// まず本を取得
+		await act(async () => {
+			await result.current.fetchBooks();
+		});
+
+		const initialCount = result.current.books.length;
+		const firstBook = result.current.books[0];
+
+		await act(async () => {
+			await result.current.deleteBook(firstBook.id);
+		});
+
+		await waitFor(() => {
+			expect(result.current.books.length).toBe(initialCount - 1);
+			expect(
+				result.current.books.find((b) => b.id === firstBook.id),
+			).toBeUndefined();
+		});
+	});
+}

--- a/frontend/features/bookshelf/types/index.ts
+++ b/frontend/features/bookshelf/types/index.ts
@@ -1,0 +1,37 @@
+/**
+ * 本棚機能の型定義
+ */
+
+export type BookStatus = "unread" | "reading" | "completed";
+
+export interface Book {
+	id: string;
+	title: string;
+	author?: string;
+	coverUrl?: string;
+	status: BookStatus;
+	type: "book" | "pdf" | "repository";
+	createdAt: string;
+	updatedAt: string;
+	notes?: string;
+	progress?: number; // 読書進捗率（0-100）
+}
+
+export interface BookshelfApiResponse {
+	books: Book[];
+	totalCount: number;
+}
+
+export interface CreateBookRequest {
+	title: string;
+	author?: string;
+	coverUrl?: string;
+	status: BookStatus;
+	type: "book" | "pdf" | "repository";
+	notes?: string;
+}
+
+export interface UpdateBookStatusRequest {
+	status: BookStatus;
+	progress?: number;
+}

--- a/frontend/test-utils.tsx
+++ b/frontend/test-utils.tsx
@@ -1,0 +1,30 @@
+/**
+ * テストユーティリティ
+ * Vitestと@testing-library/reactの共通設定
+ */
+
+import {
+	render as rtlRender,
+	renderHook as rtlRenderHook,
+} from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { vi } from "vitest";
+
+// Re-export everything
+export * from "@testing-library/react";
+export { userEvent, vi };
+
+// Custom render with providers if needed
+export function render(ui: React.ReactElement, options = {}) {
+	return rtlRender(ui, options);
+}
+
+export function renderHook<TProps, TResult>(
+	callback: (props: TProps) => TResult,
+	options = {},
+) {
+	return rtlRenderHook(callback, options);
+}
+
+// User event setup
+export const user = userEvent.setup();


### PR DESCRIPTION
## 概要
Issue #808 に基づき、本棚機能のフロントエンド一覧画面を実装しました。

## 作業内容
- ✅ `frontend/app/bookshelf/page.tsx`の作成
- ✅ `frontend/features/bookshelf/`ディレクトリ構造の作成
- ✅ 本棚一覧画面の実装
- ✅ ステータスタブ（未読・読書中・読了）の実装
- ✅ グリッドビューでの表示

## 実装した機能
- ステータス別のタブ切り替え
- グリッド形式での本の表示
- 本の追加ボタン
- 各本カードからの詳細画面への遷移（リンク）
- 本追加モーダル

## スクリーンショット
実装したデザイン：
```
┌─────────────────────────────────────────────┐
│  📚 私の本棚                                │
├─────────────────────────────────────────────┤
│ [未読] [読書中] [読了]             [本を追加] │
├─────────────────────────────────────────────┤
│ ┌─────────┐ ┌─────────┐ ┌─────────┐      │
│ │ [表紙]  │ │ [表紙]  │ │  🐙     │      │
│ │ Book 1  │ │ PDF 1   │ │ Repo 1  │      │
│ │ 読書中  │ │ 読了    │ │ 未読    │      │
│ └─────────┘ └─────────┘ └─────────┘      │
└─────────────────────────────────────────────┘
```

## テスト
- ✅ 各コンポーネントにユニットテストを実装
- ✅ Lintチェックパス
- ✅ TypeScriptの型チェックパス

## 今後の作業
- APIエンドポイントとの統合（#806完了後）
- 実際のデータでの動作確認
- E2Eテストの追加

## チェックリスト
- [x] コードレビューのためのテストを実行
- [x] 既存の画面に影響がないことを確認
- [x] レスポンシブ対応の実装
- [x] TypeScriptの厳格な型付けを適用

@claude レビューをお願いします。

Closes #808

🤖 Generated with [Claude Code](https://claude.ai/code)